### PR TITLE
Reimplementing tau decay products assignment logic after update of higgs candidate function.

### DIFF
--- a/httcp/config/categories.py
+++ b/httcp/config/categories.py
@@ -163,8 +163,7 @@ def add_categories(config: od.Config) -> None:
         name="tautau_signal_reg",
         id=10 + tautau.id,
         selection=[tautau.selection,
-                   os_charge.selection,
-                   mT_cut.selection],
+                   os_charge.selection],
         label=r"$\tau\tau$ signal region",
     )
         

--- a/httcp/config/run3_2022_preEE_tau_spinner.py
+++ b/httcp/config/run3_2022_preEE_tau_spinner.py
@@ -229,9 +229,9 @@ def add_run3_2022_preEE_tau_spinner (ana: od.Analysis,
     add_shift_aliases(cfg, "mu", {"muon_weight": "muon_weight_{direction}"})
     
     
-    cfg.add_shift(name="tauspinner_up", id=5, type="shape") #cp-even
-    cfg.add_shift(name="tauspinner_down", id=6, type="shape") #cp-odd
-    add_shift_aliases(cfg, "tauspinner", {"tauspinner_weight": "tauspinner_weight_{direction}"})
+    cfg.add_shift(name="ts_up", id=5, type="shape") #cp-even
+    cfg.add_shift(name="ts_down", id=7, type="shape") #cp-odd
+    add_shift_aliases(cfg, "ts", {"tauspinner_weight": "tauspinner_weight_{direction}"})
     # event weight columns as keys in an OrderedDict, mapped to shift instances they depend on
     get_shifts = functools.partial(get_shifts_from_sources, cfg)
     

--- a/httcp/config/variables.py
+++ b/httcp/config/variables.py
@@ -458,7 +458,7 @@ def add_hcand_features(cfg: od.Config) -> None:
             )
         
     n_bins_phi_cp = 11
-    for the_ch in ['mu_pi', 'mu_rho', 'mu_a1_1pr', "rho_rho"]:
+    for the_ch in ['mu_pi', 'mu_rho', 'mu_a1_1pr', "rho_rho","pi_pi"]:
         spitted_str = the_ch.split('_')
         if 'a1' in the_ch: 
             title_str = "\\" + spitted_str[0] + fr" a_1, {spitted_str[2]}"

--- a/httcp/production/main.py
+++ b/httcp/production/main.py
@@ -130,7 +130,6 @@ def main(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         events = self[tau_weight](events,do_syst = True, **kwargs)
         print("Producing Tauspinner weights...")
         events = self[tauspinner_weight](events, **kwargs)
-    
     print("Producing phi_cp...") 
     events = self[phi_cp](events, **kwargs) 
     return events

--- a/httcp/production/phi_cp.py
+++ b/httcp/production/phi_cp.py
@@ -21,6 +21,18 @@ warn = maybe_import("warnings")
 set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
 set_ak_column_i32 = functools.partial(set_ak_column, value_type=np.int32)
 
+@producer(
+    uses={
+        "hcand.*",
+    },
+    produces={"hcand_invm"})
+def get_hcand_inv_m(events):
+    hcand_ = ak.with_name(events.hcand, "PtEtaPhiMLorentzVector")
+    hcand1 = hcand_[:, 0:1]
+    hcand2 = hcand_[:, 1:2]
+    mass = (hcand1 + hcand2).mass
+    events = set_ak_column(events, "hcand_invm", mass)
+    return events
 
 # lambda function to get 4-vector from the particle objects
 def get_lep_p4(part): return ak.zip({f"{var}": part[var] for var in ['pt', 'eta', 'phi', 'mass']},
@@ -35,133 +47,68 @@ def get_ip_p4(part): return ak.zip({f'{var}': part[f'IP{var}']for var in ['x', '
                                    with_name="LorentzVector",
                                    behavior=coffea.nanoevents.methods.vector.behavior)
 
+def egamma_mask(tauprod): return ((np.abs(tauprod.pdgId) == 11) + (np.abs(tauprod.pdgId) == 22))
+
+def pion_mask(tauprod): return np.abs(tauprod.pdgId) == 211
+
+def get_single_part(array: ak.Array, idx: int) -> ak.Array:
+    return ak.firsts(array[:,idx:idx+1])
+
+def apply_evt_mask(array: ak.Array, mask: ak.Array) -> ak.Array:
+    empty_array = ak.zeros_like(array)[...][..., :0]
+    return ak.where(mask, array, empty_array)
+    
 
 def get_single_ch_mt(self: Producer, events: ak.Array, tau_decay_channel: str,  **kwargs):
 
     # Produce mask for different channels and tau decay modes
-    events = ak.Array(events, behavior=coffea.nanoevents.methods.nanoaod.behavior)
-    mask = events.channel_id == self.config_inst.get_channel('mutau').id
-    presel_tau = ak.firsts(events.hcand[:, 1:2])
-    presel_tauprod = ak.firsts(events.hcandprod[:, 1:2])
-    hcand_ = ak.with_name(events.hcand, "PtEtaPhiMLorentzVector")
-    hcand1 = hcand_[:, 0:1]
-    hcand2 = hcand_[:, 1:2]
-
-    mass = (hcand1 + hcand2).mass
-    events = set_ak_column(events, "hcand_invm", mass)
-
+    events  = ak.Array(events, behavior=coffea.nanoevents.methods.nanoaod.behavior)
+    mask    = events.channel_id == self.config_inst.get_channel('mutau').id
+    tau_idx = 1 #in semileptonic channels taus always have index 1 
+    mu_idx  = 0 #in semileptonic channels taus always have index 0
+    tau     = get_single_part(events.hcand, tau_idx) 
+    tauprod = get_single_part(events.hcandprod, tau_idx)
+    lep1    = get_single_part(events.hcand, mu_idx)
     # Select the events with taus and muons having ip_significance > 2
-    mask = mask & ak.fill_none(
-        ak.firsts(events.hcand[:, 0:1].ip_sig >= 2), False)
+    mask = mask & ak.fill_none(lep1.ip_sig >= 1, False)
     # Create masks for different channels
+    
     if tau_decay_channel == "mu_pi":
-        mask = mask & ak.fill_none(presel_tau.ip_sig >= 2, False)
-        mask = mask & ak.fill_none(
-            presel_tau.decayMode == 0, False)  # Get only DM0 events
-        # Check that all decay products comming from tau
-        mask = mask & ak.fill_none(
-            ak.all(presel_tauprod.tauIdx == 0, axis=1), False)
-        # Tau has only a single daughter
-        mask = mask & ak.fill_none(
-            ak.num(presel_tauprod.pt, axis=1) == 1, False)
-    elif tau_decay_channel == "mu_rho":
-        # Get only DM1 events since tau -> rho+nu -> pi^+pi^0+nu
-        mask = mask & ak.fill_none(presel_tau.decayMode == 1, False)
-        # Require only one charged product
-        mask = mask & ak.fill_none(
-            ak.sum(presel_tauprod.charge != 0, axis=1) == 1, False)
-        # Require only one neutral product
-        mask = mask & ak.fill_none(
-            ak.sum(presel_tauprod.charge == 0, axis=1) == 1, False)
-    elif tau_decay_channel == "mu_a1_1pr":
-        # Get only DM2 events since tau -> a1 + nu -> rho + pi0 + nu
-        mask = mask & ak.fill_none(presel_tau.decayMode == 1, False)
-        # Require only one charged product
-        mask = mask & ak.fill_none(
-            ak.sum(presel_tauprod.charge != 0, axis=1) == 1, False)
-        # Check if all three decay products are comming from the same tau
-        mask = mask & ak.fill_none(
-            ak.sum(presel_tauprod.charge == 0, axis=1) == 2, False)
-        mask = mask & ak.fill_none(
-            ak.sum(presel_tauprod.tauIdx == 0, axis=1) == 3, False)
-    elif tau_decay_channel == "mu_a1_3pr":
-        # Get only DM1 events since tau -> pho+nu -> pi^+pi^0+nu
-        mask = mask & presel_tau.decayMode == 10
-        # Require only one charged product
-        mask = mask & ak.fill_none(
-            ak.sum(presel_tauprod.charge != 0, axis=1) == 3, False)
-        # Check if all three decay products are comming from the same tau
-        mask = mask & ak.fill_none(
-            ak.sum(presel_tauprod.tauIdx == 0, axis=1) == 3, False)
+        mask = mask & ak.fill_none(tau.ip_sig >= 1, False)
+        mask = mask & ak.fill_none(tau.decayMode == 0, False)  # Get only DM0 events
+        mask = mask & ak.fill_none(ak.sum(pion_mask(tauprod), axis=1) == 1, False) #Make sure that event conteins only one pion
 
-    empty_hcand_arr = ak.zeros_like(events.hcand)[...][..., :0]
-    empty_hcandprod_arr = ak.zeros_like(events.hcandprod)[...][..., :0]
-    sel_hcand = ak.where(mask, events.hcand, empty_hcand_arr)
-    sel_hcandprod = ak.where(mask, events.hcandprod, empty_hcandprod_arr)
+    elif tau_decay_channel == "mu_rho":
+        mask = mask & ak.fill_none(tau.decayMode == 1, False) # Get only DM1 events since tau -> rho+nu -> pi^+pi^0+nu
+        mask = mask & ak.fill_none(ak.sum(pion_mask(tauprod), axis=1) == 1, False)# Require only one charged pion
+        mask = mask & ak.fill_none(ak.sum(egamma_mask(tauprod), axis=1) >= 1, False) # Require one or more electron or photon
+  
+    hcand     = apply_evt_mask(events.hcand,     mask)
+    hcandprod = apply_evt_mask(events.hcandprod, mask)
     # Defining a preliminary set of parameters for the function to calculate the acoplanarity angle
     # lower case variables are defined in laboratory frame
     # Get p1 and r1 that correspond to kinematic 4-vector and impact parameter vector of the muon
-    p1 = get_lep_p4(sel_hcand[:, 0:1])
-    r1 = get_ip_p4(sel_hcand[:, 0:1])
-    ch1 = sel_hcand[:, 0:1].charge
-    
+    muon = get_single_part(hcand, mu_idx)
+    p1 = get_lep_p4(muon)
+    r1 = get_ip_p4(muon)
+    ch1 = muon.charge
+    tau     = get_single_part(hcand, tau_idx)
+    tauprod = get_single_part(hcandprod, tau_idx) # it has deminsionality evt * var * tauprod
     if tau_decay_channel == "mu_pi":
-        # flatten is needed since there can be multiple decay products for one tau, and DM0 explicitly states that there is only one identified as a decay product.
-        p2 = get_lep_p4(ak.flatten(sel_hcandprod, axis=2))
-        # Create 4-vectors of tau impact parameters
-        r2 = get_ip_p4(sel_hcand[:, 1:2])
-        # For this channel there is no need to do the phase shift, so this arrray is filled with False statements
+        pion    = get_single_part(ak.mask(tauprod, pion_mask(tauprod)),0)
+        p2 = get_lep_p4(pion) # for the tau -> rho decay, p1 - is 4-vector of the charged pion and r1 is 4-vector of the neutral pion
+        r2 = get_ip_p4(tau) # Create 4-vectors of tau impact parameters
+        # For this channel there is no need to do the phase shift, so this arrray is filled with zeros
         do_phase_shift = ak.zeros_like(r1.energy, dtype=np.bool_)
     elif tau_decay_channel == "mu_rho":
-        # Get the charged pion and neutral separately
-        charged_pion_mask = sel_hcandprod.charge != 0
-        neutral_pion_mask = sel_hcandprod.charge == 0
+        charged_pion = get_single_part(ak.mask(tauprod, pion_mask(tauprod)),0)
+        em_particles = ak.mask(tauprod, egamma_mask(tauprod))
         # for the tau -> rho decay, p1 - is 4-vector of the charged pion and r1 is 4-vector of the neutral pion
-        p2 = get_lep_p4(ak.flatten(ak.drop_none(
-            ak.mask(sel_hcandprod, charged_pion_mask)), axis=2))
-        r2 = get_lep_p4(ak.flatten(ak.drop_none(
-            ak.mask(sel_hcandprod, neutral_pion_mask)), axis=2))
+        p2 = get_lep_p4(charged_pion)
+        # Create 4-vectors of tau impact parameters
+        r2 = get_lep_p4(em_particles).sum()
+        r2 = ak.mask(r2, r2.rho2 > 0)
         do_phase_shift = ((p2.energy - r2.energy)/(p2.energy + r2.energy)) < 0
-    elif tau_decay_channel == "mu_a1_1pr":
-        # Get the charged and neutral pions separately
-        charged_pion_mask = sel_hcandprod.charge != 0
-        neutral_pion_mask = sel_hcandprod.charge == 0
-        # for the tau -> a1 decay, p1 - is 4-vector of the charged pion and r1 is 4-vector of the neutral system of two neutral particles
-        p2 = get_lep_p4(ak.flatten(ak.drop_none(
-            ak.mask(sel_hcandprod, charged_pion_mask)), axis=2))
-        neutral_pion = ak.mask(sel_hcandprod, neutral_pion_mask)[:, 1:2]
-        neutral_pion1 = get_lep_p4(ak.flatten(
-            ak.drop_none(neutral_pion), axis=2)[:, 0:1])
-        neutral_pion2 = get_lep_p4(ak.flatten(
-            ak.drop_none(neutral_pion), axis=2)[:, 1:2])
-        r2 = neutral_pion1.add(neutral_pion2)
-        do_phase_shift = ((p2.energy - r2.energy)/(p2.energy + r2.energy)) < 0
-
-    # elif tau_decay_channel == "a1_3pr":
-    #     #Get flat array for taus and 2d array for tauprods
-    #     flat_tau = ak.firsts(sel_hcand[:,1:2])
-    #     tauprod = ak.flatten(sel_hcandprod[:,1:2],axis=2)
-    #     #broadcast arrays so it's possible to compare charge of tau with the charge of tau decay products
-    #     tau, _ = ak.broadcast_arrays(flat_tau, tauprod)
-    #     #Get 4-vectors of pions that have same sign with tau and one pion that has opposite sign
-    #     ss_pi_mask  = tau.charge == tauprod.charge
-    #     os_pi_mask  = tau.charge == -1*tauprod.charge
-
-    #     pv_inputs = {}
-    #     #There should be two same size pions and one opposite size pion
-    #     empty_hcandprod = events.hcandprod[0,0,:0]
-    #     empty_hcand     = events.hcand[0,:0]
-    #     ss_pi   = ak.drop_none(ak.mask(tauprod,ss_pi_mask), axis=1)
-    #     #Take the first pion with the same charge as tau
-    #     pv_inputs['ss_pion1_p4']  = get_lep_p4(ak.fill_none(ss_pi[:,0:1], empty_hcandprod, axis=0))
-    #     #Take the second pion with the same charge as tau
-    #     pv_inputs['ss_pion2_p4']  = get_lep_p4(ak.fill_none(ss_pi[:,1:2], empty_hcandprod, axis=0))
-    #     #Take take opposite charge pion
-    #     pv_inputs['os_pion_p4']   = get_lep_p4(ak.fill_none(ak.drop_none(ak.mask(tauprod,os_pi_mask), axis=1),empty_hcandprod, axis=0))
-    #     pv_inputs['tau_p4']       = get_lep_p4(ak.fill_none(flat_tau,empty_hcand, axis=0))
-    #     pv_inputs['tau_charge']   = ak.fill_none(flat_tau.charge,empty_hcand.charge, axis=0)
-
-    #     tau_dp_p4 = pv_inputs['ss_pion1_p4'].add(pv_inputs['ss_pion2_p4']).add(pv_inputs['os_pion_p4'])
 
     vecs_p4 = {}
     for var in ['p1', 'p2', 'r1', 'r2']:
@@ -171,76 +118,65 @@ def get_single_ch_mt(self: Producer, events: ak.Array, tau_decay_channel: str,  
 
 
 def get_single_ch_tt(self: Producer, events: ak.Array,  tau_decay_channel: str,  **kwargs):
-
+    
     # Produce mask for different channels and tau decay modes
-    # Currently the code works for e-tau and mu-tau channels
-    events = ak.Array(
-        events, behavior=coffea.nanoevents.methods.nanoaod.behavior)
-    mask = events.channel_id == self.config_inst.get_channel('tautau').id
-    hcand_ = ak.with_name(events.hcand, "PtEtaPhiMLorentzVector")
-    hcand1 = hcand_[:, 0:1]
-    hcand2 = hcand_[:, 1:2]
+    events  = ak.Array(events, behavior=coffea.nanoevents.methods.nanoaod.behavior)
+    mask    = events.channel_id == self.config_inst.get_channel('tautau').id
+    tau = []
+    tauprod = []
+    for tau_idx in range(2):
+        tau.append(get_single_part(events.hcand, tau_idx)) 
+        tauprod.append(get_single_part(events.hcandprod, tau_idx))
+    
+    
+    # Create masks for different channels
+    
+    if tau_decay_channel == "pi_pi":
+        for tau_idx in range(2):
+            mask = mask & ak.fill_none(tau[tau_idx].decayMode == 0, False)  # Get only DM0 events
+            mask = mask & ak.fill_none(tau[tau_idx].ip_sig >= 1, False)
+            mask = mask & ak.fill_none(ak.sum(pion_mask(tauprod[tau_idx]), axis=1) == 1, False) #Make sure that event conteins only one pion
 
-    mass = (hcand1 + hcand2).mass
-    events = set_ak_column(events, "hcand_invm", mass)
-
-    leg1_tau = ak.firsts(events.hcand[:, 0:1])
-    leg2_tau = ak.firsts(events.hcand[:, 1:2])
-    leg1_prod = ak.firsts(events.hcandprod[:, 0:1])
-    leg2_prod = ak.firsts(events.hcandprod[:, 1:2])
-
-    if tau_decay_channel == "rho_rho":
-        # Get only DM1 events since tau -> rho+nu -> pi^+pi^0+nu
-        mask = mask & ak.fill_none(leg1_tau.decayMode == 1, False)
-        # Require only one charged product
-        mask = mask & ak.fill_none(
-            ak.sum(leg1_prod.charge != 0, axis=1) == 1, False)
-        # Require only one neutral product
-        mask = mask & ak.fill_none(
-            ak.sum(leg1_prod.charge == 0, axis=1) == 1, False)
-
-        mask = mask & ak.fill_none(leg2_tau.decayMode == 1, False)
-        # Require only one charged product
-        mask = mask & ak.fill_none(
-            ak.sum(leg2_prod.charge != 0, axis=1) == 1, False)
-        # Require only one neutral product
-        mask = mask & ak.fill_none(
-            ak.sum(leg2_prod.charge == 0, axis=1) == 1, False)
-
-    empty_hcand_arr = ak.zeros_like(events.hcand)[...][..., :0]
-    empty_hcandprod_arr = ak.zeros_like(events.hcandprod)[...][..., :0]
-    sel_hcand = ak.where(mask, events.hcand, empty_hcand_arr)
-    sel_hcandprod = ak.where(mask, events.hcandprod, empty_hcandprod_arr)
+    elif tau_decay_channel == "rho_rho":
+        for tau_idx in range(2):
+            mask = mask & ak.fill_none(tau[tau_idx].decayMode == 1, False) # Get only DM1 events since tau -> rho+nu -> pi^+pi^0+nu
+            mask = mask & ak.fill_none(ak.sum(pion_mask(tauprod[tau_idx]), axis=1) == 1, False)# Require only one charged pion
+            mask = mask & ak.fill_none(ak.sum(egamma_mask(tauprod[tau_idx]), axis=1) >= 1, False) # Require one or more electron or photon
+    hcand     = apply_evt_mask(events.hcand,     mask)
+    hcandprod = apply_evt_mask(events.hcandprod, mask)
     # Defining a preliminary set of parameters for the function to calculate the acoplanarity angle
     # lower case variables are defined in laboratory frame
     # Get p1 and r1 that correspond to kinematic 4-vector and impact parameter vector of the muon
-
-    ch1 = sel_hcand[:, 0:1].charge
-
-    leg1_tau = sel_hcand[:, 0:1]
-    leg2_tau = sel_hcand[:, 1:2]
-    leg1_prod = sel_hcandprod[:, 0:1]
-    leg2_prod = sel_hcandprod[:, 1:2]
-    y = ak.ones_like(leg1_tau.pt)
+    # Redefine taus and tauprods now from preselected events
+    tau = []
+    tauprod = []
+    for tau_idx in range(2):
+        tau.append(get_single_part(hcand, tau_idx)) 
+        tauprod.append(get_single_part(hcandprod, tau_idx))
+    
     vecs_p4 = {}
-    if tau_decay_channel == "rho_rho":
-        for i in range(1, 3):
-            # Get the charged pion and neutral separately
-
-            tau_obj = eval(f'leg{i}_tau')
-            tauprod_obj = eval(f'leg{i}_prod')
-            charged_pion_mask = tauprod_obj.charge != 0
-            neutral_pion_mask = tauprod_obj.charge == 0
+    ch1 = tau[0].charge
+    if tau_decay_channel == "pi_pi":
+        for tau_idx in range(2):
+            charged_pion = get_single_part(ak.mask(tauprod[tau_idx], pion_mask(tauprod[tau_idx])),0)
+            vecs_p4[f"p{tau_idx+1}"] = get_lep_p4(charged_pion)
+            vecs_p4[f"r{tau_idx+1}"] = get_ip_p4(tau[tau_idx])
+        do_phase_shift = ak.zeros_like(vecs_p4["p1"].energy, dtype=np.bool_)
+    elif tau_decay_channel == "rho_rho":
+        y = []
+        for tau_idx in range(2):
+            charged_pion = get_single_part(ak.mask(tauprod[tau_idx], pion_mask(tauprod[tau_idx])),0)
+            em_particles = ak.mask(tauprod[tau_idx], egamma_mask(tauprod[tau_idx]))
             # for the tau -> rho decay, p1 - is 4-vector of the charged pion and r1 is 4-vector of the neutral pion
-            p = get_lep_p4(ak.flatten(ak.drop_none(
-                ak.mask(tauprod_obj, charged_pion_mask)), axis=2))
-            r = get_lep_p4(ak.flatten(ak.drop_none(
-                ak.mask(tauprod_obj, neutral_pion_mask)), axis=2))
-            vecs_p4[f"p{i}"] = p
-            vecs_p4[f"r{i}"] = r
-            y = y * ((p.energy - r.energy)/(p.energy + r.energy))
+            p = get_lep_p4(charged_pion)
+            r = get_lep_p4(em_particles).sum()
+            r = ak.mask(r, r.rho2 > 0)
+            vecs_p4[f"r{tau_idx+1}"] = p
+            vecs_p4[f"p{tau_idx+1}"] = r
+            y.append((p.energy - r.energy)/(p.energy + r.energy))
+        do_phase_shift = (y[0] * y[1]) < 0
 
-    return events, vecs_p4, y < 0, ch1
+    return events, vecs_p4, do_phase_shift, ch1
 
 
 def make_boost(vecs_p4, boostvec=None):
@@ -295,7 +231,7 @@ def produce_dy_alpha(
     return dy_alpha
 
 
-channels = ['mu_pi', 'mu_rho', 'mu_a1_1pr', 'rho_rho']
+channels = ['mu_pi','mu_rho','pi_pi','rho_rho']
 
 
 @producer(
@@ -318,7 +254,7 @@ channels = ['mu_pi', 'mu_rho', 'mu_a1_1pr', 'rho_rho']
         optional(f"phi_cp_{the_ch}_reg2_2bin") for the_ch in channels
     } | {
         optional(f"alpha_{the_ch}") for the_ch in channels
-    } | {"hcand_invm"}
+    } 
 
 )
 def phi_cp(
@@ -337,30 +273,30 @@ def phi_cp(
             events, vecs_p4, do_phase_shift, ch1 = get_single_ch_tt(
                 self, events, the_ch)
         zmf_vecs_p4 = make_boost(vecs_p4)
-        phi_cp = ak.firsts(get_acop_angle(zmf_vecs_p4, do_phase_shift))
-        alpha_per_ch = produce_dy_alpha(vecs_p4, ch1)
-        alpha = ak.where(ak.num(alpha_per_ch) > 0,
-                         ak.fill_none(ak.firsts(alpha_per_ch), EMPTY_FLOAT),
-                         alpha)
-        reg1_mask = ak.fill_none(ak.firsts(alpha_per_ch >= np.pi/4.), False)
-        reg2_mask = ak.fill_none(
-            ak.firsts((alpha_per_ch < np.pi/4.) & (alpha_per_ch >= 0.)), False)
+        phi_cp = get_acop_angle(zmf_vecs_p4, do_phase_shift)
+        # alpha_per_ch = produce_dy_alpha(vecs_p4, ch1)
+        # alpha = ak.where(ak.num(alpha_per_ch) > 0,
+        #                  ak.fill_none(ak.firsts(alpha_per_ch), EMPTY_FLOAT),
+        #                  alpha)
+        # reg1_mask = ak.fill_none(ak.firsts(alpha_per_ch >= np.pi/4.), False)
+        # reg2_mask = ak.fill_none(
+        #     ak.firsts((alpha_per_ch < np.pi/4.) & (alpha_per_ch >= 0.)), False)
 
         phi_cp_2bin = (phi_cp + np.pi/2.) % (2*np.pi)
         events = set_ak_column_f32(
             events, f"phi_cp_{the_ch}_2bin",  ak.fill_none(phi_cp_2bin, EMPTY_FLOAT))
 
-        for the_reg in ['reg1', 'reg2']:
-            var = ak.where(eval(f'{the_reg}_mask'), phi_cp, EMPTY_FLOAT)
-            var_2bin = ak.where(
-                eval(f'{the_reg}_mask'), phi_cp_2bin, EMPTY_FLOAT)
+        # for the_reg in ['reg1', 'reg2']:
+        #     var = ak.where(eval(f'{the_reg}_mask'), phi_cp, EMPTY_FLOAT)
+        #     var_2bin = ak.where(
+        #         eval(f'{the_reg}_mask'), phi_cp_2bin, EMPTY_FLOAT)
 
-            events = set_ak_column_f32(
-                events, f"phi_cp_{the_ch}_{the_reg}",  var)
-            events = set_ak_column_f32(events, f"phi_cp_{the_ch}_{the_reg}_2bin",  var_2bin)
+        #     events = set_ak_column_f32(
+        #         events, f"phi_cp_{the_ch}_{the_reg}",  var)
+        #     events = set_ak_column_f32(events, f"phi_cp_{the_ch}_{the_reg}_2bin",  var_2bin)
 
-        events = set_ak_column_f32(
-            events, f'alpha_{the_ch}', ak.fill_none(alpha, EMPTY_FLOAT))
+        # events = set_ak_column_f32(
+        #     events, f'alpha_{the_ch}', ak.fill_none(alpha, EMPTY_FLOAT))
         events = set_ak_column_f32(
             events, f"phi_cp_{the_ch}",  ak.fill_none(phi_cp, EMPTY_FLOAT))
     return events

--- a/httcp/production/weights.py
+++ b/httcp/production/weights.py
@@ -426,6 +426,7 @@ def tauspinner_weight(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
                 buf[np.isnan(buf)] = 0
                 the_weight = buf
         else:
-            the_weight = np.ones_like(events.event, dtype=np.float32)  
-        events = set_ak_column_f32(events, f"tauspinner_weight{the_name}", the_weight)  
+            print("Tauspinner column does not exist for this sample: filling weights with ones")
+            the_weight = np.ones_like(events.event, dtype=np.float32)
+        events = set_ak_column_f32(events, f"tauspinner_weight{the_name}", the_weight)
     return events

--- a/httcp/selection/higgscand.py
+++ b/httcp/selection/higgscand.py
@@ -338,14 +338,13 @@ def higgscandprod(
     events   = self[assign_tauprod_mass_charge](events)
 
     tauprods = events.TauProd
-
     tau_mask = events.hcand.decayMode >=0
-    tau_idx = events.hcand.rawIdx[tau_mask]
-
+    tau_idx = ak.mask(events.hcand.rawIdx,tau_mask)
+    
     tauprods_mask = tauprods.tauIdx
     idx_pairs = ak.cartesian([tau_idx,tauprods.tauIdx], axis=1, nested=True)
     tau_idx_b, tau_prod_idx_b = ak.unzip(idx_pairs)
-    prod_mask = tau_idx_b == tau_prod_idx_b
+    prod_mask = ak.fill_none(tau_idx_b == tau_prod_idx_b, False)
     evt_masks = []
     evt_dm_only_masks = []
     tau_prods = []

--- a/httcp/selection/higgscand.py
+++ b/httcp/selection/higgscand.py
@@ -3,17 +3,21 @@
 """
 Prepare h-Candidate from SelectionResult: selected lepton indices & channel_id [trigger matched]
 """
-
+import functools
 from typing import Optional
 from columnflow.selection import Selector, SelectionResult, selector
 from columnflow.util import maybe_import
 from columnflow.columnar_util import EMPTY_FLOAT, Route, set_ak_column
+from columnflow.util import DotDict
 
 from httcp.util import enforce_hcand_type, enforce_tauprods_type, trigger_object_matching, hlt_path_fired, has_pt_greater_equal, has_delta_r_less_equal, HLT_path_matching
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
 coffea = maybe_import("coffea")
+
+set_ak_column_f32 = functools.partial(set_ak_column, value_type=np.float32)
+set_ak_column_i32 = functools.partial(set_ak_column, value_type=np.int32)
 
 
 @selector(
@@ -160,26 +164,18 @@ def select_tauprods(hcand_idx, tauprods):
     return hcandprods
 
 
-def is_pion(prods): return ((np.abs(prods.pdgId) == 211)
-                            | (np.abs(prods.pdgId) == 321))
-
+def is_pion(prods): return ((np.abs(prods.pdgId) == 211))
+#                            | (np.abs(prods.pdgId) == 321))
 
 def is_photon(prods): return prods.pdgId == 22
 
+def has_one_pion(prods): return (ak.sum(is_pion(prods),   axis=1) == 1)
 
-def has_one_pion(prods): return (
-    ak.sum(is_pion(prods),   axis=1) == 1)[:, None]
+def has_three_pions(prods): return (ak.sum(is_pion(prods),   axis=1) == 3)
 
+def has_photons(prods): return (ak.sum(is_photon(prods), axis=1) > 0)
 
-def has_three_pions(prods): return (
-    ak.sum(is_pion(prods),   axis=1) == 3)[:, None]
-
-
-def has_photons(prods): return (ak.sum(is_photon(prods), axis=1) > 0)[:, None]
-
-
-def has_no_photons(prods): return (
-    ak.sum(is_photon(prods), axis=1) == 0)[:, None]
+def has_no_photons(prods): return (ak.sum(is_photon(prods), axis=1) == 0)
 
 
 @selector(
@@ -196,29 +192,60 @@ def assign_tauprod_mass_charge(
         events: ak.Array,
         **kwargs
 ) -> ak.Array:
-    pionp = 211
-    pionm = -211
-    kaonp = 321
-    kaonm = -321
-    gamma = 22
+    # pionp = 211
+    # pionm = -211
+    # kaonp = 321
+    # kaonm = -321
+    # gamma = 22
 
-    mass = ak.where(np.abs(events.TauProd.pdgId) == pionp,
-                    0.13957,
-                    ak.where(np.abs(events.TauProd.pdgId) == kaonp,
-                             0.493677,
-                             ak.where(events.TauProd.pdgId == gamma,
-                                      0.0, 0.0))
-                    )
-    charge = ak.where(((events.TauProd.pdgId == pionp) | (events.TauProd.pdgId == kaonp)),
-                      1.0,
-                      ak.where(((events.TauProd.pdgId == pionm) | (events.TauProd.pdgId == kaonm)),
-                               -1.0,
-                               0.0)
-                      )
+    # mass = ak.where(np.abs(events.TauProd.pdgId) == pionp,
+    #                 0.13957,
+    #                 ak.where(np.abs(events.TauProd.pdgId) == kaonp,
+    #                          0.493677,
+    #                          ak.where(events.TauProd.pdgId == gamma,
+    #                                   0.0, 0.0))
+    #                 )
+    # charge = ak.where(((events.TauProd.pdgId == pionp) | (events.TauProd.pdgId == kaonp)),
+    #                   1.0,
+    #                   ak.where(((events.TauProd.pdgId == pionm) | (events.TauProd.pdgId == kaonm)),
+    #                            -1.0,
+    #                            0.0)
+    #                   )
 
-    events = set_ak_column(events, "TauProd.mass", mass)
-    events = set_ak_column(events, "TauProd.charge", charge)
-
+    # events = set_ak_column(events, "TauProd.mass", mass)
+    # events = set_ak_column(events, "TauProd.charge", charge)
+    
+    #https://pdg.lbl.gov/2023/listings/particle_properties.html
+    
+    part_dict=DotDict.wrap({
+        "pion_pm"   : {'mass'    : 0.13957039, #GeV
+                       'pdg_id'  : 211},
+        "pion_0"    : {'mass'    : 0.1349768, #GeV
+                       'pdg_id'  : 111},
+        "gamma"     : {'mass'    : 0.0, #GeV
+                       'pdg_id'  : 22},
+        "kaon_pm"   : {'mass'    : 0.493677, #GeV
+                       'pdg_id'  : 321},
+        "ele_pm"    : {'mass'    : 0.00051099895, #GeV
+                       'pdg_id'  : 11},
+        "muon_pm"   : {'mass'    : 0.1056583755, #GeV
+                       'pdg_id'  : 13},
+        })
+    mass = ak.zeros_like(ak.local_index(events.TauProd.pdgId), dtype=np.float32)
+    charge = ak.zeros_like(ak.local_index(events.TauProd.pdgId), dtype=np.int32)
+    for part in part_dict:
+       
+        prod_id = events.TauProd.pdgId
+        mass = ak.where(np.abs(prod_id)==part_dict[part].pdg_id,
+                        part_dict[part].mass,
+                        mass)
+        if '_pm' in part:
+            charge = ak.where(np.abs(prod_id)==part_dict[part].pdg_id,
+                              np.sign(prod_id),
+                              charge)
+    
+    events = set_ak_column_f32(events, "TauProd.mass", mass)
+    events = set_ak_column_i32(events, "TauProd.charge", charge)
     return events
 
 
@@ -238,63 +265,124 @@ def higgscandprod(
         hcand_array: ak.Array,
         **kwargs
 ) -> tuple[ak.Array, SelectionResult]:
-    etau_id   = self.config_inst.get_channel("etau").id
-    mutau_id  = self.config_inst.get_channel("mutau").id
-    tautau_id = self.config_inst.get_channel("tautau").id
+    # etau_id   = self.config_inst.get_channel("etau").id
+    # mutau_id  = self.config_inst.get_channel("mutau").id
+    # tautau_id = self.config_inst.get_channel("tautau").id
+
+    # events   = self[assign_tauprod_mass_charge](events)
+
+    # tauprods = events.TauProd
+
+    # hcand1 = events.hcand[:, 0:1]
+    # hcand2 = events.hcand[:, 1:2]
+
+    # hcand1_idx = hcand1.rawIdx
+    # hcand2_idx = hcand2.rawIdx
+
+    # hcand1prods = ak.where(events.channel_id == tautau_id,
+    #                        select_tauprods(hcand1_idx, tauprods),
+    #                        tauprods[:, :0])
+    # hcand2prods = ak.where(((events.channel_id == etau_id) | (events.channel_id == mutau_id) | (events.channel_id == tautau_id)),
+    #                        select_tauprods(hcand2_idx, tauprods),
+    #                        tauprods[:, :0])
+
+    # dummy = (events.event >= 0)[:, None]
+    # hcand1_mask = ak.where(hcand1.decayMode == 0,
+    #                        (has_one_pion(hcand1prods) &
+    #                         has_no_photons(hcand1prods)),
+    #                        ak.where(((hcand1.decayMode == 1) | (hcand1.decayMode == 2)),
+    #                                 (has_one_pion(hcand1prods) &
+    #                                  has_photons(hcand1prods)),
+    #                                 ak.where(hcand1.decayMode == 10,
+    #                                          has_three_pions(hcand1prods),
+    #                                          ak.where(hcand1.decayMode == 11,
+    #                                                   (has_three_pions(hcand1prods)
+    #                                                    & has_photons(hcand1prods)),
+    #                                                   dummy)
+    #                                          )
+    #                                 )
+    #                        )
+    # hcand2_mask = ak.where(hcand2.decayMode == 0,
+    #                        (has_one_pion(hcand2prods) &
+    #                         has_no_photons(hcand2prods)),
+    #                        ak.where(((hcand2.decayMode == 1) | (hcand2.decayMode == 2)),
+    #                                 (has_one_pion(hcand2prods) &
+    #                                  has_photons(hcand2prods)),
+    #                                 ak.where(hcand2.decayMode == 10,
+    #                                          has_three_pions(hcand2prods),
+    #                                          ak.where(hcand2.decayMode == 11,
+    #                                                   (has_three_pions(hcand2prods)
+    #                                                    & has_photons(hcand2prods)),
+    #                                                   dummy)
+    #                                          )
+    #                                 )
+    #                        )
+
+    # hcand_prod_mask = ak.concatenate([hcand1_mask, hcand2_mask], axis=1)
+
+    # hcand_prods = ak.concatenate(
+    #     [hcand1prods[:, None], hcand2prods[:, None]], axis=1)
+
+    # hcand_prods_array = enforce_hcand_type(ak.from_regular(hcand_prods),
+    #                                        {"pt": "float64",
+    #                                         "eta": "float64",
+    #                                         "phi": "float64",
+    #                                         "mass": "float64",
+    #                                         "charge": "int64",
+    #                                         "pdgId": "int64",
+    #                                         "tauIdx": "int64"}
+    #                                        )
+    # hcand_prods_array = ak.from_regular(hcand_prods)
+    # events = set_ak_column(events, "hcandprod", hcand_prods_array)
 
     events   = self[assign_tauprod_mass_charge](events)
 
     tauprods = events.TauProd
 
-    hcand1 = events.hcand[:, 0:1]
-    hcand2 = events.hcand[:, 1:2]
+    tau_mask = events.hcand.decayMode >=0
+    tau_idx = events.hcand.rawIdx[tau_mask]
 
-    hcand1_idx = hcand1.rawIdx
-    hcand2_idx = hcand2.rawIdx
+    tauprods_mask = tauprods.tauIdx
+    idx_pairs = ak.cartesian([tau_idx,tauprods.tauIdx], axis=1, nested=True)
+    tau_idx_b, tau_prod_idx_b = ak.unzip(idx_pairs)
+    prod_mask = tau_idx_b == tau_prod_idx_b
+    evt_masks = []
+    evt_dm_only_masks = []
+    tau_prods = []
+    for idx in range(2): #iteate over taus
+        tau = ak.firsts(events.hcand[:,idx:idx+1])
+        tau_prod = tauprods[ak.flatten(prod_mask[:,idx:idx+1],axis=2)]
+        false_prod_mask = ak.zeros_like(ak.local_index(tau_prod,axis=1), dtype=np.bool_)
+        mask = ak.ones_like(ak.local_index(tau_prod,axis=1), dtype=np.bool_)
+        #DM0
+        mask = ak.fill_none(tau.decayMode==0, False) & has_one_pion(tau_prod) #& has_no_photons(tau_prod)
+        #DM1
+        mask = mask | ak.fill_none(tau.decayMode==1, False) & has_one_pion(tau_prod) & has_photons(tau_prod)
+        #DM10
+        mask = mask | ak.fill_none(tau.decayMode==10, False) & has_three_pions(tau_prod) #& has_no_photons(tau_prod)
+        #DM11
+        mask = mask | ak.fill_none(tau.decayMode==11, False) & has_three_pions(tau_prod) & has_no_photons(tau_prod)
+        #DM -1, -2 for electron / muon
+        mask = mask | ak.fill_none(tau.decayMode < 0, False)
+        evt_masks.append(mask)
+        
+        dm_only_mask = (ak.fill_none(tau.decayMode==0, False) | ak.fill_none(tau.decayMode==1, False) |
+        ak.fill_none(tau.decayMode==10, False) | ak.fill_none(tau.decayMode==11, False) | ak.fill_none(tau.decayMode < 0, False))
+        
+        evt_dm_only_masks.append(dm_only_mask)
+        tau_prods.append(tau_prod[:,None])
+                
+    etau_id   = self.config_inst.get_channel("etau").id
+    mutau_id  = self.config_inst.get_channel("mutau").id
+    tautau_id = self.config_inst.get_channel("tautau").id
 
-    hcand1prods = ak.where(events.channel_id == tautau_id,
-                           select_tauprods(hcand1_idx, tauprods),
-                           tauprods[:, :0])
-    hcand2prods = ak.where(((events.channel_id == etau_id) | (events.channel_id == mutau_id) | (events.channel_id == tautau_id)),
-                           select_tauprods(hcand2_idx, tauprods),
-                           tauprods[:, :0])
-
-    dummy = (events.event >= 0)[:, None]
-    hcand1_mask = ak.where(hcand1.decayMode == 0,
-                           (has_one_pion(hcand1prods) &
-                            has_no_photons(hcand1prods)),
-                           ak.where(((hcand1.decayMode == 1) | (hcand1.decayMode == 2)),
-                                    (has_one_pion(hcand1prods) &
-                                     has_photons(hcand1prods)),
-                                    ak.where(hcand1.decayMode == 10,
-                                             has_three_pions(hcand1prods),
-                                             ak.where(hcand1.decayMode == 11,
-                                                      (has_three_pions(hcand1prods)
-                                                       & has_photons(hcand1prods)),
-                                                      dummy)
-                                             )
-                                    )
-                           )
-    hcand2_mask = ak.where(hcand2.decayMode == 0,
-                           (has_one_pion(hcand2prods) &
-                            has_no_photons(hcand2prods)),
-                           ak.where(((hcand2.decayMode == 1) | (hcand2.decayMode == 2)),
-                                    (has_one_pion(hcand2prods) &
-                                     has_photons(hcand2prods)),
-                                    ak.where(hcand2.decayMode == 10,
-                                             has_three_pions(hcand2prods),
-                                             ak.where(hcand2.decayMode == 11,
-                                                      (has_three_pions(hcand2prods)
-                                                       & has_photons(hcand2prods)),
-                                                      dummy)
-                                             )
-                                    )
-                           )
-
-    hcand_prod_mask = ak.concatenate([hcand1_mask, hcand2_mask], axis=1)
-
-    hcand_prods = ak.concatenate(
-        [hcand1prods[:, None], hcand2prods[:, None]], axis=1)
+    joint_evt_mask = (events.channel_id == tautau_id) & evt_masks[0] & evt_masks[1]
+    joint_evt_mask = joint_evt_mask + (((events.channel_id == etau_id) | (events.channel_id == mutau_id)) & evt_masks[0]) 
+    
+    joint_evt_dm_mask = (events.channel_id == tautau_id) & evt_dm_only_masks[0] & evt_dm_only_masks[1]
+    joint_evt_dm_mask = joint_evt_mask + (((events.channel_id == etau_id) | (events.channel_id == mutau_id)) & evt_dm_only_masks[0]) 
+        
+    hcand_prods = ak.concatenate(tau_prods, axis=1)
 
     hcand_prods_array = enforce_hcand_type(ak.from_regular(hcand_prods),
                                            {"pt": "float64",
@@ -310,6 +398,7 @@ def higgscandprod(
 
     return events, SelectionResult(
         steps={
-            "decay_prods_are_ok": ak.sum(hcand_prod_mask, axis=1) == 2,
+            "decay_mode_mask"   : joint_evt_dm_mask,
+            "decay_prods_are_ok": joint_evt_mask,
         },
     )

--- a/httcp/selection/main.py
+++ b/httcp/selection/main.py
@@ -7,6 +7,7 @@ Exemplary selection methods.
 from typing import Optional
 from operator import and_
 from functools import reduce
+
 from collections import defaultdict, OrderedDict
 
 from columnflow.selection import Selector, SelectionResult, selector
@@ -216,18 +217,13 @@ def main(
     at_least_one_hcand = ak.num(hcand_pairs, axis=-1) > 0
 
     # check if there are at least one hcand [before trigger obj matching]
-    # _lepton_indices = ak.concatenate([good_muon_indices, good_ele_indices, good_tau_indices], axis=1)
     prematch_mask = ak.sum(ak.num(hcand_pairs, axis=-1) > 0, axis=1) > 0
-    # ((ak.num(_lepton_indices, axis=1) >= 2) & (ak.num(good_tau_indices, axis=1) >= 1))
-    # hcand results
+   
     events, good_muon_indices, good_ele_indices, good_tau_indices, etau_channel_mask, mutau_channel_mask, tautau_channel_mask, hcand_array, hcand_results = self[higgscand](
         events, trigger_results, hcand_pairs, domatch=True)
 
     # check if there are at least two leptons with at least one tau [after trigger obj matching]
-    # _lepton_indices = ak.concatenate([good_muon_indices, good_ele_indices, good_tau_indices], axis=1)
-    at_least_one_hcand_matched = ak.num(hcand_array, axis=-1) == 2
-    postmatch_mask = at_least_one_hcand_matched
-    # ((ak.num(_lepton_indices, axis=1) >= 2) & (ak.num(good_tau_indices, axis=1) >= 1))
+    postmatch_mask = ak.num(hcand_array, axis=-1) == 2
     match_res = SelectionResult(
         steps={
             "selected_hcand": prematch_mask,
@@ -255,11 +251,11 @@ def main(
 
     # gen particles info
     # hcand-gentau match = True/False
-    if "is_signal" in list(self.dataset_inst.aux.keys()):
-        if self.dataset_inst.aux["is_signal"]:
-            # print("hcand-gentau matching")
-            events, gentau_results = self[gentau_selection](events, True)
-            results += gentau_results
+    # if "is_signal" in list(self.dataset_inst.aux.keys()):
+    #     if self.dataset_inst.aux["is_signal"]:
+    #         # print("hcand-gentau matching")
+    #         events, gentau_results = self[gentau_selection](events, True)
+    #         results += gentau_results
 
     selected_objects = SelectionResult(
         objects={

--- a/httcp/selection/trigger.py
+++ b/httcp/selection/trigger.py
@@ -44,9 +44,7 @@ def trigger_selection(
         # skip the trigger if it does not apply to the dataset
         #if not trigger.applies_to_dataset(self.dataset_inst):
         #    continue
-        # get bare decisions
-        any_fired = any_fired | events.HLT[trigger.hlt_field]
-        # get trigger objects for fired events per leg
+        #perform leg-specific selections first
         leg_masks = []
         all_legs_match = ak.ones_like(index, dtype=np.bool_)
         
@@ -72,7 +70,11 @@ def trigger_selection(
             leg_masks.append(index[leg_mask])
             # at least one object must match this leg
             all_legs_match = all_legs_match & ak.any(leg_mask, axis=1)
-
+        
+       
+        # get bare decisions
+        fired = events.HLT[trigger.hlt_field]
+        any_fired = any_fired | fired
         # final trigger decision
         fired_and_all_legs_match = fired & all_legs_match
         any_fired_all_legs_match = any_fired_all_legs_match | fired_and_all_legs_match

--- a/httcp/weights/main.py
+++ b/httcp/weights/main.py
@@ -23,7 +23,6 @@ def main(self: WeightProducer, events: ak.Array, **kwargs) -> ak.Array:
     weight = ak.Array(np.ones(len(events), dtype=np.float32))
     for column in self.weight_columns:
         weight = weight * Route(column).apply(events)
-
     return events, weight
 
 
@@ -42,6 +41,6 @@ def main_init(self: WeightProducer) -> None:
 
     # declare shifts that the produced event weight depends on
     shift_sources = {
-       "tauspinner",
+       "ts",
     }
     self.shifts |= set(get_shifts_from_sources(self.config_inst, *shift_sources))


### PR DESCRIPTION
Fixed the problem of low selection efficiency after implementing proper triggers. 
The core of the problem was that when selecting masks in the following line:
https://github.com/DesyTau/CPinHToTauTau/blob/01d4bc475eb00536af48ea4ae035c5ed30ee95b4/httcp/selection/higgscand.py#L158C2-L158C47
there was used direct skimming of the tau prods array that is potentially unsafe. It can be that by doing this we remove some of the tauprods and not putting Nones in their places. So it will result in taking the wrong tauprods in the latter steps. 
A new procedure of assigning tau products is channel-independent until the last step of mask creation. Before that, there is a consistent selection of the first tau from each pair, then it is matched with its tau products, the masks are saved, and then the process is performed for the second tau. To perform the matching of tau indices and indices of tau products ak.broadcast function is used, so the dimensionality of masks is saved. 
