### PR TITLE
Fixes for mutau production

### DIFF
--- a/httcp/config/categories.py
+++ b/httcp/config/categories.py
@@ -75,7 +75,8 @@ def add_categories(config: od.Config,
                        "deep_tau_wp",
                        "b_veto"     ,
                        ],
-            label=r"$mu\tau$ no mt",
+            label=r"$\mu\tau$ no mt",
+            aux={'control_reg': "mutau_control_reg_no_mt"} 
         )
         mutau_control_reg_no_mt = add_category(
             config,

--- a/httcp/config/categories.py
+++ b/httcp/config/categories.py
@@ -157,7 +157,7 @@ def add_categories(config: od.Config,
                        "tau_endcap" ,
                        ],
             label=r"$\mu\tau$ no mt \n $\eta_{\tau} > 1.2$",
-            aux={'control_reg': "mutau_control_reg_endcap_tau"}
+            aux={'control_reg': "mutau_control_reg_endcap_tau_no_mt"}
         )
         mutau_control_reg_endcap_tau_no_mt = add_category(
             config,
@@ -183,7 +183,7 @@ def add_categories(config: od.Config,
                        "tau_barrel" ,
                        ],
             label=r"$\mu\tau$ no mt \n $\eta_{\tau} \leq 1.2$",
-            aux={'control_reg': "mutau_control_reg_barrel_tau"}
+            aux={'control_reg': "mutau_control_reg_barrel_tau_no_mt"}
         )
 
         mutau_control_reg_barrel_tau_no_mt = add_category(
@@ -330,7 +330,7 @@ def add_categories(config: od.Config,
                        "tau_endcap" ,
                        ],
             label=r"$e\tau$ no mt signal region\n $\eta_{\tau} > 1.2$",
-            aux={'control_reg': "etau_control_reg_endcap_tau"}
+            aux={'control_reg': "etau_control_reg_endcap_tau_no_mt"}
         )
         etau_control_reg_endcap_tau_no_mt = add_category(
             config,
@@ -358,7 +358,7 @@ def add_categories(config: od.Config,
                         "tau_barrel" ,
                         ],
             label=r"$e\tau$ no mt signal region\n $\eta_{\tau} \leq 1.2$",
-            aux={'control_reg': "etau_control_reg_barrel_tau"}
+            aux={'control_reg': "etau_control_reg_barrel_tau_no_mt"}
         )
 
         etau_control_reg_barrel_tau_no_mt = add_category(

--- a/httcp/config/categories.py
+++ b/httcp/config/categories.py
@@ -66,9 +66,9 @@ def add_categories(config: od.Config,
                        ],
             label=r"$\mu\tau$ control region",
         )
-        mutau_no_mt = add_category(
+        mutau_signal_reg_no_mt = add_category(
             config,
-            name="mutau_no_mt",
+            name="mutau_signal_reg_no_mt",
             id=200 + mutau.id,
             selection=["cat_mutau"  ,
                        "os_charge"  ,
@@ -146,6 +146,59 @@ def add_categories(config: od.Config,
             label=r"$\mu\tau$ control region\n $\eta_{\tau} \leq 1.2$",
         )
 
+        mutau_signal_reg_endcap_tau_no_mt  = add_category(
+            config,
+            name="mutau_signal_reg_endcap_tau_no_mt",
+            id=500 + mutau.id,
+            selection=["cat_mutau"  ,
+                       "os_charge"  ,
+                       "deep_tau_wp",
+                       "b_veto"     ,
+                       "tau_endcap" ,
+                       ],
+            label=r"$\mu\tau$ no mt \n $\eta_{\tau} > 1.2$",
+            aux={'control_reg': "mutau_control_reg_endcap_tau"}
+        )
+        mutau_control_reg_endcap_tau_no_mt = add_category(
+            config,
+            name="mutau_control_reg_endcap_tau_no_mt",
+            id=550 + mutau.id,
+            selection=["cat_mutau"  ,
+                       "ss_charge"  ,
+                       "deep_tau_wp",
+                       "b_veto"     ,
+                       "tau_endcap" ,
+                       ],
+            label=r"$\mu\tau$ no mt control region\n $\eta_{\tau} > 1.2$",
+        )
+
+        mutau_signal_reg_barrel_tau_no_mt = add_category(
+            config,
+            name="mutau_signal_reg_barrel_tau_no_mt",
+            id=600 + mutau.id,
+            selection=["cat_mutau"  ,
+                       "os_charge"  ,
+                       "deep_tau_wp",
+                       "b_veto"     ,
+                       "tau_barrel" ,
+                       ],
+            label=r"$\mu\tau$ no mt \n $\eta_{\tau} \leq 1.2$",
+            aux={'control_reg': "mutau_control_reg_barrel_tau"}
+        )
+
+        mutau_control_reg_barrel_tau_no_mt = add_category(
+            config,
+            name="mutau_control_reg_barrel_tau_no_mt",
+            id=650 + mutau.id,
+            selection=["cat_mutau"  ,
+                       "ss_charge"  ,
+                       "deep_tau_wp",
+                       "b_veto"     ,
+                       "tau_barrel" ,
+                       ],
+            label=r"$\mu\tau$ no mt control region\n $\eta_{\tau} \leq 1.2$",
+        )
+
     elif channel=='etau':
         etau = add_category(
             config,
@@ -210,7 +263,7 @@ def add_categories(config: od.Config,
         
         etau_signal_reg_endcap_tau = add_category(
             config,
-            name="mutau_signal_reg_endcap_tau",
+            name="etau_signal_reg_endcap_tau",
             id=300 + etau.id,
             selection=["cat_etau"   ,
                        "os_charge"  ,
@@ -264,6 +317,63 @@ def add_categories(config: od.Config,
                         ],
             label=r"$e\tau$ control region\n $\eta_{\tau} \leq 1.2$",
         )
+
+        etau_signal_reg_endcap_tau_no_mt = add_category(
+            config,
+            name="etau_signal_reg_endcap_tau_no_mt",
+            id=500 + etau.id,
+            selection=["cat_etau"   ,
+                       "os_charge"  ,
+                       "mt_cut"     ,
+                       "deep_tau_wp",
+                       "b_veto"     ,
+                       "tau_endcap" ,
+                       ],
+            label=r"$e\tau$ no mt signal region\n $\eta_{\tau} > 1.2$",
+            aux={'control_reg': "etau_control_reg_endcap_tau"}
+        )
+        etau_control_reg_endcap_tau_no_mt = add_category(
+            config,
+            name="etau_control_reg_endcap_tau_no_mt",
+            id=550 + etau.id,
+            selection=["cat_etau"   ,
+                       "ss_charge"  ,
+                       "mt_cut"     ,
+                       "deep_tau_wp",
+                       "b_veto"     ,
+                       "tau_endcap" ,
+                       ],
+            label=r"$e\tau$ no mt control region\n $\eta_{\tau} > 1.2$",
+        )
+
+        etau_signal_reg_barrel_tau_no_mt = add_category(
+            config,
+            name="etau_signal_reg_barrel_tau_no_mt",
+            id=600 + etau.id,
+            selection=["cat_etau"  ,
+                        "os_charge"  ,
+                        "mt_cut"     ,
+                        "deep_tau_wp",
+                        "b_veto"     ,
+                        "tau_barrel" ,
+                        ],
+            label=r"$e\tau$ no mt signal region\n $\eta_{\tau} \leq 1.2$",
+            aux={'control_reg': "etau_control_reg_barrel_tau"}
+        )
+
+        etau_control_reg_barrel_tau_no_mt = add_category(
+            config,
+            name="etau_control_reg_barrel_tau_no_mt",
+            id=650 + etau.id,
+            selection=["cat_etau"  ,
+                        "ss_charge"  ,
+                        "deep_tau_wp",
+                        "b_veto"     ,
+                        "tau_barrel" ,
+                        ],
+            label=r"$e\tau$ no mt control region\n $\eta_{\tau} \leq 1.2$",
+        )
+
     
     elif channel=='tautau':
         tautau = add_category(

--- a/httcp/config/variables.py
+++ b/httcp/config/variables.py
@@ -421,34 +421,34 @@ def phi_cp_variables(cfg: od.Config) -> None:
             x_title=rf"$\varphi_{{CP}} [{title_str}], \alpha \geq \pi/4$ (rad)",
         )
         # 2-bin histograms
-        cfg.add_variable(
-            name=f"phi_cp_{the_ch}_2bin",
-            expression=f"phi_cp_{the_ch}_2bin",
-            null_value=EMPTY_FLOAT,
-            binning=(2, 0, 2*np.pi), 
-            x_title=rf"$\varphi_{{CP}} [{title_str}]$ (rad)",
-        )
-        cfg.add_variable(
-            name=f"phi_cp_{the_ch}_reg1_2bin",
-            expression=f"phi_cp_{the_ch}_reg1_2bin",
-            null_value=EMPTY_FLOAT,
-            binning=(2, 0, 2*np.pi),
-            x_title=rf"$\varphi_{{CP}} [{title_str}], \alpha < \pi/4$ (rad)",
-        )
-        cfg.add_variable(
-            name=f"phi_cp_{the_ch}_reg2_2bin",
-            expression=f"phi_cp_{the_ch}_reg2_2bin",
-            null_value=EMPTY_FLOAT,
-            binning=(2, 0, 2*np.pi),
-            x_title=rf"$\varphi_{{CP}} [{title_str}], \alpha \geq \pi/4$ (rad)",
-        )
-        cfg.add_variable(
-            name=f"alpha_{the_ch}",
-            expression=f"alpha_{the_ch}",
-            null_value=EMPTY_FLOAT,
-            binning=(6, 0, np.pi/2),
-            x_title=rf"$ \alpha [{title_str}] $(rad)",
-        )
+#        cfg.add_variable(
+#            name=f"phi_cp_{the_ch}_2bin",
+#            expression=f"phi_cp_{the_ch}_2bin",
+#            null_value=EMPTY_FLOAT,
+#            binning=(2, 0, 2*np.pi), 
+#            x_title=rf"$\varphi_{{CP}} [{title_str}]$ (rad)",
+#        )
+#        cfg.add_variable(
+#            name=f"phi_cp_{the_ch}_reg1_2bin",
+#            expression=f"phi_cp_{the_ch}_reg1_2bin",
+#            null_value=EMPTY_FLOAT,
+#            binning=(2, 0, 2*np.pi),
+#            x_title=rf"$\varphi_{{CP}} [{title_str}], \alpha < \pi/4$ (rad)",
+#        )
+#        cfg.add_variable(
+#            name=f"phi_cp_{the_ch}_reg2_2bin",
+#            expression=f"phi_cp_{the_ch}_reg2_2bin",
+#            null_value=EMPTY_FLOAT,
+#            binning=(2, 0, 2*np.pi),
+#            x_title=rf"$\varphi_{{CP}} [{title_str}], \alpha \geq \pi/4$ (rad)",
+#        )
+#        cfg.add_variable(
+#            name=f"alpha_{the_ch}",
+#            expression=f"alpha_{the_ch}",
+#            null_value=EMPTY_FLOAT,
+#            binning=(6, 0, np.pi/2),
+#            x_title=rf"$ \alpha [{title_str}] $(rad)",
+#        )
 
 def add_dilepton_features(cfg: od.Config) -> None:
     channels = cfg.channels.names()
@@ -594,7 +594,7 @@ def add_variables(cfg: od.Config) -> None:
     add_lepton_features(cfg)
     add_jet_features(cfg)
     add_highlevel_features(cfg)
-    phi_cp_variables(cfg)
+    #phi_cp_variables(cfg)
     add_weight_features(cfg)
     add_cutflow_features(cfg)
     add_dilepton_features(cfg)

--- a/httcp/data_driven/hist_hooks.py
+++ b/httcp/data_driven/hist_hooks.py
@@ -61,7 +61,7 @@ def add_hist_hooks(config: od.Config) -> None:
         signal_categories : dict[str, dict[str, od.Category]] = defaultdict(DotDict)
         #Filling the dictionay with signal histograms
         for the_name in config.categories.names():
-            if 'signal_reg' in the_name or the_name=="mutau_no_mt":
+            if 'signal_reg' in the_name:
                 signal_categories[the_name] = config.get_category(the_name)
         
 

--- a/httcp/data_driven/hist_hooks.py
+++ b/httcp/data_driven/hist_hooks.py
@@ -61,7 +61,7 @@ def add_hist_hooks(config: od.Config) -> None:
         signal_categories : dict[str, dict[str, od.Category]] = defaultdict(DotDict)
         #Filling the dictionay with signal histograms
         for the_name in config.categories.names():
-            if 'signal_reg' in the_name:
+            if 'signal_reg' in the_name or the_name=="mutau_no_mt":
                 signal_categories[the_name] = config.get_category(the_name)
         
 

--- a/httcp/production/main.py
+++ b/httcp/production/main.py
@@ -48,7 +48,7 @@ set_ak_column_i32 = functools.partial(set_ak_column, value_type=np.int32)
         get_mc_weight,
         hcand_fields,
         tauspinner_weight,
-        phi_cp,
+        #phi_cp,
         category_ids,
         "Jet.pt",
         "Jet.pt_no_jec",
@@ -65,7 +65,7 @@ set_ak_column_i32 = functools.partial(set_ak_column, value_type=np.int32)
         zpt_weight,
         hcand_fields,
         tauspinner_weight,
-        phi_cp,
+        #phi_cp,
         category_ids,
         "Jet.jec_no_jec_diff",
         "Jet.number_of_jets",
@@ -108,6 +108,6 @@ def main(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         ch_str = ' '.join([str(ch) for ch in channel])
         raise ValueError(f"attempt to process more than one channel: {ch_str}")
     else: channel = channel[0]
-    if channel=='mutau':
-        events = self[phi_cp](events, **kwargs) 
+#    if channel=='mutau':
+        #events = self[phi_cp](events, **kwargs) 
     return events

--- a/scripts/common_run3.sh
+++ b/scripts/common_run3.sh
@@ -4,10 +4,10 @@ set_common_vars() {
 
 version="dev"
     
-categories_mutau="mutau_signal_reg" 
+categories_mutau="mutau_signal_reg,mutau_signal_reg_no_mt,mutau_signal_reg_endcap_tau,mutau_signal_reg_barrel_tau,mutau_signal_reg_endcap_tau_no_mt,mutau_signal_reg_barrel_tau_no_mt" 
 variables_mutau='mutau_lep0_pt,mutau_lep0_eta,mutau_lep0_phi,mutau_lep0_ip_sig,mutau_lep1_pt,mutau_lep1_eta,mutau_lep1_phi,mutau_lep1_mass,mutau_lep1_decayModePNet,mutau_lep1_decayMode,mutau_mt,mutau_mvis,mutau_delta_r,mutau_pt,puppi_met_pt,puppi_met_phi'
 
-categories_etau="etau_signal_reg" 
+categories_etau="etau_signal_reg,etau_signal_reg_no_mt" 
 variables_etau='jet_1_pt,etau_lep0_pt,etau_lep0_eta,etau_lep0_phi,etau_lep0_ip_sig,etau_lep1_pt,etau_lep1_eta,etau_lep1_phi,etau_lep1_mass,etau_lep1_decayModePNet,etau_lep1_decayMode,etau_mt,etau_mvis,etau_delta_r,etau_pt,puppi_met_pt,puppi_met_phi'
 
 data_e_2022preEE='data_e_C,data_e_D,'


### PR DESCRIPTION
Quick fixes I implemented during the latest run mutau postEE production, we have two issues: 

1. phi-cp variable calculation failed, so I removed it
2. mutau no mt is mislabeled so I hardcoded the category name in the QCD estimation. 
I was thinking that instead of asking for `signal_reg` in the category name, we could instead run QCD estimation if `aux={'control_reg': "mutau_control_reg_no_mt"} ` is provided. 
Anyway, this PR should not be merged, just wanted to note these changes so that we properly implement these fixes 
