### PR TITLE
Fix electron weights and add extra categories

### DIFF
--- a/httcp/categorization/main.py
+++ b/httcp/categorization/main.py
@@ -107,6 +107,34 @@ def deep_tau_wp(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array
     return events, mask
 
 @categorizer(uses={'event', 'hcand_*'})
+def deep_tau_wp_mtt(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
+    channels = self.config_inst.channels.names()
+    deep_tau_vs_e_jet_wps = self.config_inst.x.deep_tau.vs_e_jet_wps
+    deep_tau_vs_mu_wps = self.config_inst.x.deep_tau.vs_mu_wps
+
+    mask = ak.zeros_like(events.event, dtype=np.bool_)
+    for channel in channels:
+        tau = events[f'hcand_{channel}'].lep1
+        channel_mask = ak.ones_like(events[f'hcand_{channel}'].lep1.rawIdx)
+        if channel == 'mutau':
+            channel_mask = channel_mask & (tau.idDeepTau2018v2p5VSjet >= deep_tau_vs_e_jet_wps["Medium"])
+            channel_mask = channel_mask & (tau.idDeepTau2018v2p5VSe   >= deep_tau_vs_e_jet_wps["Tight"])
+            channel_mask = channel_mask & (tau.idDeepTau2018v2p5VSmu  >= deep_tau_vs_mu_wps["Tight"])
+        elif channel == 'etau':
+            channel_mask = channel_mask & (tau.idDeepTau2018v2p5VSjet >= deep_tau_vs_e_jet_wps["Medium"])
+            channel_mask = channel_mask & (tau.idDeepTau2018v2p5VSe   >= deep_tau_vs_e_jet_wps["Tight"])
+            channel_mask = channel_mask & (tau.idDeepTau2018v2p5VSmu  >= deep_tau_vs_mu_wps["Tight"])
+        elif "tautau":
+            tau0 = events[f'hcand_{channel}'].lep0
+            for the_tau in [tau, tau0]:
+                channel_mask = channel_mask & (the_tau.idDeepTau2018v2p5VSjet >= deep_tau_vs_e_jet_wps["Medium"])
+                channel_mask = channel_mask & (the_tau.idDeepTau2018v2p5VSe   >= deep_tau_vs_e_jet_wps["VVLoose"])
+                channel_mask = channel_mask & (the_tau.idDeepTau2018v2p5VSmu  >= deep_tau_vs_mu_wps["VLoose"])
+        mask = mask | ak.fill_none(ak.firsts(channel_mask, axis=1),False)
+    return events, mask
+
+
+@categorizer(uses={'event', 'hcand_*'})
 def deep_tau_inv_wp(self: Categorizer, events: ak.Array, **kwargs) -> tuple[ak.Array, ak.Array]:
     channels = self.config_inst.channels.names()
     deep_tau_vs_e_jet_wps = self.config_inst.x.deep_tau.vs_e_jet_wps

--- a/httcp/config/categories.py
+++ b/httcp/config/categories.py
@@ -24,7 +24,6 @@ def add_categories(config: od.Config,
         selection="cat_incl",
         label="inclusive",
     )
-     
     ##############################################
     ### Main categories for the three channels ###
     ##############################################
@@ -53,7 +52,7 @@ def add_categories(config: od.Config,
             label=r"$\mu\tau$ signal region",
             aux={'control_reg': "mutau_control_reg"}
         )
-        
+
         mutau_control_reg = add_category(
             config,
             name="mutau_control_reg",
@@ -197,6 +196,53 @@ def add_categories(config: od.Config,
                        "tau_barrel" ,
                        ],
             label=r"$\mu\tau$ no mt control region\n $\eta_{\tau} \leq 1.2$",
+        )
+
+        mutau_signal_reg_no_mt_bveto_wp_mtt = add_category(
+            config,
+            name="mutau_signal_reg_no_mt_bveto_wp_mtt",
+            id=700 + mutau.id,
+            selection=["cat_mutau"  ,
+                       "os_charge"  ,
+                       "deep_tau_wp_mtt",
+                      ],
+            label=r"$\mu\tau$ signal region no mt, mtt wp, no b veto",
+            aux={'control_reg': "mutau_contol_reg_no_mt_bveto_wp_mtt"}
+        )
+
+        mutau_contol_reg_no_mt_bveto_wp_mtt = add_category(
+            config,
+            name="mutau_contol_reg_no_mt_bveto_wp_mtt",
+            id=750 + mutau.id,
+            selection=["cat_mutau"  ,
+                       "ss_charge"  ,
+                       "deep_tau_wp_mtt",
+                      ],
+            label=r"$\mu\tau$ control region no mt, mtt wp, no b veto",
+        )
+
+
+        mutau_signal_reg_no_mt_bveto_wp_mtt = add_category(
+            config,
+            name="mutau_signal_reg_no_mt_bveto",
+            id=800 + mutau.id,
+            selection=["cat_mutau"  ,
+                       "os_charge"  ,
+                       "deep_tau_wp",
+                      ],
+            label=r"$\mu\tau$ signal region no mt, no b veto",
+            aux={'control_reg': "mutau_contol_reg_no_mt_bveto"}
+        )
+
+        mutau_contol_reg_no_mt_bveto = add_category(
+            config,
+            name="mutau_contol_reg_no_mt_bveto",
+            id=850 + mutau.id,
+            selection=["cat_mutau"  ,
+                       "ss_charge"  ,
+                       "deep_tau_wp",
+                      ],
+            label=r"$\mu\tau$ control region no mt, no b veto",
         )
 
     elif channel=='etau':
@@ -369,6 +415,54 @@ def add_categories(config: od.Config,
                         "tau_barrel" ,
                         ],
             label=r"$e\tau$ no mt control region\n $\eta_{\tau} \leq 1.2$",
+        )
+
+
+        etau_signal_reg_no_mt_bveto_wp_mtt = add_category(
+            config,
+            name="etau_signal_reg_no_mt_bveto_wp_mtt",
+            id=700 + etau.id,
+            selection=["cat_etau"  ,
+                       "os_charge"  ,
+                       "deep_tau_wp_mtt",
+                      ],
+            label=r"$e\tau$ signal region no mt, mtt wp, no b veto",
+            aux={'control_reg': "etau_contol_reg_no_mt_bveto_wp_mtt"}
+        )
+
+        etau_contol_reg_no_mt_bveto_wp_mtt = add_category(
+            config,
+            name="etau_contol_reg_no_mt_bveto_wp_mtt",
+            id=750 + etau.id,
+            selection=["cat_etau"  ,
+                       "ss_charge"  ,
+                       "deep_tau_wp_mtt",
+                      ],
+            label=r"$e\tau$ control region no mt, mtt wp, no b veto",
+        )
+
+
+        etau_signal_reg_no_mt_bveto_wp_mtt = add_category(
+            config,
+            name="etau_signal_reg_no_mt_bveto",
+            id=800 + etau.id,
+            selection=["cat_etau"  ,
+                       "os_charge"  ,
+                       "deep_tau_wp",
+                      ],
+            label=r"$e\tau$ signal region no mt, no b veto",
+            aux={'control_reg': "etau_contol_reg_no_mt_bveto"}
+        )
+
+        etau_contol_reg_no_mt_bveto = add_category(
+            config,
+            name="etau_contol_reg_no_mt_bveto",
+            id=850 + etau.id,
+            selection=["cat_etau"  ,
+                       "ss_charge"  ,
+                       "deep_tau_wp",
+                      ],
+            label=r"$e\tau$ control region no mt, no b veto",
         )
 
     

--- a/httcp/production/weights.py
+++ b/httcp/production/weights.py
@@ -195,10 +195,14 @@ def electron_weight(self: Producer, events: ak.Array, do_syst: bool,  **kwargs) 
                 electron = hcand[lep]
                 # Create sf array template to make copies and dict for finnal results of all systematics
                 pt =  flat_np_view(electron.pt,axis=1) #take the first particle from the hcand pair
-                eta =  flat_np_view(abs(electron.eta),axis=1)
+                eta =  flat_np_view(electron.eta,axis=1)
+                phi =  flat_np_view(electron.phi,axis=1)
                 #Prepare a tuple with the inputs of the correction evaluator
-                ele_sf_args_idiso = lambda syst : (year_id,syst,wp_id,eta,pt)
-                ele_sf_args_trigger = lambda syst : (year_trigger,syst,wp_trigger,eta,pt)
+                if "2023" in year_id:
+                    ele_sf_args_idiso = lambda syst : (year_id,syst,wp_id,eta,pt,phi)
+                else:
+                    ele_sf_args_idiso = lambda syst :(year_id,syst,wp_id,eta,pt)
+                ele_sf_args_trigger = lambda syst :(year_trigger,syst,wp_trigger,eta,pt)
                 #Loop over the shifts and calculate for each shift electron scale factor
                 for the_shift in shifts:
                     flat_sf = ak.ones_like(pt)


### PR DESCRIPTION
- in 2023 the id iso scale factors also depend on phi 
- Relevant for 2022, looks like we are not doing it correctly @jmalvaso, it should depend on eta not absolute eta [here](https://github.com/DesyTau/CPinHToTauTau/compare/desy_dev...anigamova:CPinHToTauTau:2023_campaign_elesf?expand=1#diff-11253fb87d356fe0efbfb1180d33ce7757dda3ff073914b105d3e211dcf605baR198) . It might resolve some of the disagreements 
- Adding categories with alternative selections 
