### PR TITLE
add signals h_ggf_htt cpo,sm,mm for pre+postEE

### DIFF
--- a/httcp/config/config_run3.py
+++ b/httcp/config/config_run3.py
@@ -181,6 +181,9 @@ def add_run3(ana: od.Analysis,
         "st_twchannel_tbar_fh",
         #SM Higgs signal
         "h_ggf_htt_filtered",
+        "h_ggf_htt_cpo_filtered",
+        "h_ggf_htt_mm_filtered",
+        "h_ggf_htt_sm_filtered",
         ]
 
     dataset_names_2022postEE = [
@@ -225,6 +228,9 @@ def add_run3(ana: od.Analysis,
         "st_twchannel_tbar_fh",
         #higgs signal ggf
         "h_ggf_htt_filtered",
+        "h_ggf_htt_cpo_filtered",
+        "h_ggf_htt_mm_filtered",
+        "h_ggf_htt_sm_filtered",
         ]
 
     dataset_names_2023preBPix = [
@@ -694,8 +700,8 @@ def add_run3(ana: od.Analysis,
     
     jsonpog_dir = "/afs/cern.ch/user/a/anigamov/public/htt_corrections_mirror/jsonpog-integration_latest/POG/"
     jsonpog_tau_dir = "/afs/cern.ch/user/a/anigamov/public/htt_corrections_mirror/jsonpog-integration_tau_latest/POG/"
-    corr_dir = "/afs/cern.ch/user/a/anigamov/public/htt_corrections_mirror/"
-    j_dir ="/afs/cern.ch/user/j/jmalvaso/public/hleprare/TriggerScaleFactors/"
+    #corr_dir = "/afs/cern.ch/user/a/anigamov/public/htt_corrections_mirror/"   
+    corr_dir = "/eos/user/a/anigamov/htt_corrections_mirror/"
     golden_ls = { 
         2022 : "https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions22/Cert_Collisions2022_355100_362760_Golden.json", 
         2023 : "https://cms-service-dqmdc.web.cern.ch/CAF/certification/Collisions23/Cert_Collisions2023_366442_370790_Golden.json"
@@ -709,8 +715,8 @@ def add_run3(ana: od.Analysis,
 
         "pu_sf"                         : (f"{jsonpog_dir}LUM/{cfg.x.year}_{tag}/puWeights.json.gz", "v1"),
         "muon_correction"               : f"{jsonpog_dir}MUO/{cfg.x.year}_{tag}/muon_Z.json.gz",
-        "cross_mutau_mu_leg" : f"{j_dir}/{cfg.x.year}{campaign.x.tag}/CrossMuTauHlt_MuLeg_v1.json",
-        "HLT_mu_eff"      : f"{j_dir}/{cfg.x.year}{campaign.x.tag}/MuHlt_abseta_pt_wEff.json",
+        "cross_mutau_mu_leg"            : f"{corr_dir}hleprare/TriggerScaleFactors/{cfg.x.year}{campaign.x.tag}/CrossMuTauHlt_MuLeg_v1.json",
+        "HLT_mu_eff"                    : f"{corr_dir}hleprare/TriggerScaleFactors/{cfg.x.year}{campaign.x.tag}/MuHlt_abseta_pt_wEff.json",
         "electron_scaling_smearing"     : f"{jsonpog_dir}EGM/{cfg.x.year}_{tag}/electronSS.json.gz",
         "electron_idiso"                : f"{jsonpog_dir}EGM/{cfg.x.year}_{tag}/electron.json.gz",
         "electron_trigger"              : f"{jsonpog_dir}EGM/{cfg.x.year}_{tag}/electronHlt.json.gz",


### PR DESCRIPTION
This PR adds the HCP signals in the data name lists for 2022preEE and 2022postEE in `~/httcp/config/config_run3.py`.
The added signals are : 
-  "h_ggf_htt_cpo_filtered", 
-  "h_ggf_htt_mm_filtered", 
-  "h_ggf_htt_sm_filtered",

Note : the updated file paths (below) ensure the code runs properly
