### PR TITLE
Merge the 2 fastMTT algorithms into one fast one -> mass, eta_i, phi_i, pt_i

### DIFF
--- a/httcp/production/fastMTT.py
+++ b/httcp/production/fastMTT.py
@@ -125,6 +125,11 @@ def fastMTT(
         fast_mtt_unflattened[the_var] = ak.unflatten(the_arr, ak.num(hcand.mass,axis=1)) 
     MTT_cpp_rest = ak.zip(fast_mtt_unflattened) # -> mass, x1, x1_BW, x1_cons, x2, x2_BW, x2_cons
 
+    ''' ATTENTION : x1_BW and x2_BW denote Boson Mass Window, not Breit Wigner ! 
+    
+        (Breit Wigner can be used in apply_fastMTT.py and 
+        ~/CPinHToTauTau/modules/ClassicsSVfit/python/FastMTT.py l.37)'''
+
 
     # Extract reconstructed MTT Higgs mass and decay products properties
     hcand_features = ['pt', 'eta', 'phi'] #no 'px', 'py', 'pz', in lep so far (put can be used in apply_fastMTT.py)

--- a/httcp/production/fastMTT.py
+++ b/httcp/production/fastMTT.py
@@ -1,0 +1,158 @@
+# coding: utf-8
+
+"""
+A producer to apply FastMTT to the lepton candidates in the hcand columns.
+This reconstructs the full 4-momenta of the tau leptons via a scan over the 
+di-tau mass hypothesis, using the MET as a constraint on the neutrino system.
+
+Use cases :
+-> corrected tau pTs -> phicp
+-> corrected di-Tau mass -> TauTheDifference BDT for signal vs. background separation of the Higgs CP analysis
+"""
+
+import functools
+import law
+import os
+import sys
+import order as od
+from typing import Optional
+
+sys.path.append(os.path.dirname(os.path.realpath(__file__))) #This is needed to import fastmtt_cpp.so
+import fastmtt_cpp
+
+from columnflow.production import Producer, producer
+from columnflow.production.util import attach_coffea_behavior
+
+from columnflow.util import maybe_import, dev_sandbox
+from columnflow.util import DotDict, InsertableDict
+from columnflow.columnar_util import EMPTY_FLOAT, Route, set_ak_column, flat_np_view
+from columnflow.columnar_util import optional_column as optional
+
+# FastMTT implementation (precompiled C++ backend wrapped for Python)
+from modules.ClassicsSVfit.python.FastMTT import FastMTT
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+coffea = maybe_import("coffea")
+pd = maybe_import("pandas")
+cnmn = maybe_import("coffea.nanoevents.methods.nanoaod")
+
+# helpers
+set_ak_column_f32 = functools.partial(set_ak_column, value_dc_type=np.float32)
+set_ak_column_i32 = functools.partial(set_ak_column, value_dc_type=np.int32)
+
+logger = law.logger.get_logger(__name__)
+
+@producer(
+    uses={
+        # nano columns
+        'event',
+        'hcand_*',
+        'PuppiMET*', #here : change from PuppiMET.pt, PuppiMET.phi, PuppiMET.covXX, PuppiMET.covXY, PuppiMET.covYY
+    },
+    produces={
+        # new columns
+        'hcand_*',
+    },
+)
+
+def fastMTT(
+    self: Producer,
+    events: ak.Array,
+    **kwargs
+) -> ak.Array:
+    
+    def make_vector(p4):
+        return ak.zip({
+            'x': ak.from_regular(ak.Array(p4[:, 0:1])),
+            'y': ak.from_regular(ak.Array(p4[:, 1:2])),
+            'z': ak.from_regular(ak.Array(p4[:, 2:3])),
+            't': ak.from_regular(ak.Array(p4[:, 3:4])),
+        }, with_name='LorentzVector', behavior=coffea.nanoevents.methods.vector.behavior)
+
+    ch_str = self.config_inst.channels.names()[0] # Gives list of strings with current channel ID e.g 'mutau'
+    ch_obj = self.config_inst.x.ch_objects[ch_str]
+
+    hcand = events[f'hcand_{ch_str}']
+    met = events.PuppiMET
+
+    print('Running fastMTT (be patient)')
+
+
+    # Steering Parameters for the FastMTT algorithm
+    verbosity = True
+    delta = 1.0/1.15 # regularization parameter delta
+    reg_order = 6.0  # regularization parameter order
+    mX = 125.10 # Higgs mass
+    widthX = 2.5 # window
+    #if args.sample=='dy':
+    #mX = 91.2 # Z boson mass
+    #widthX = 4.0 # window
+
+    # Prepare input features
+    N = len(flat_np_view(hcand.lep0.pt, axis=1))
+    lep_features = ['pt','eta','phi','mass']
+    
+    features_list = [int(N)]
+    
+    for lep_str in ['lep0', 'lep1']:
+        lep = getattr(hcand, lep_str)
+        for the_var in lep_features:
+            features_list.append(flat_np_view(getattr(lep, the_var), axis=1).astype(np.float64))
+            ####################################
+            # decay_type = 0 : tau -> electron #
+            #            = 1 : tau -> muon     #
+            #            = 2 : tau -> hadrons  #
+            ####################################
+        decay_type = np.ones_like(flat_np_view(lep.pt, axis=1),dtype=np.int32)
+        if ch_obj[lep_str] == 'Electron'    : decay_type = np.right_shift(1, decay_type)
+        if ch_obj[lep_str] == 'Tau'         : decay_type = np.left_shift(1, decay_type)
+        features_list.append(decay_type)
+            
+    met_features = ['pt','phi','covXX','covXY','covYY']
+    for the_var in met_features:
+        features_list.append(flat_np_view(getattr(met, the_var)).astype(np.float64))
+    
+    fastmtt_kwargs = [verbosity,delta,reg_order,mX,widthX]
+    for the_var in fastmtt_kwargs:
+        features_list.append(the_var)
+    
+    
+    # === Run FastMTT ===
+    fast_mtt_res = fastmtt_cpp.fastmtt_cpp(*features_list)
+    fast_mtt_unflattened = {}
+    for the_var, the_arr in fast_mtt_res.items():
+        fast_mtt_unflattened[the_var] = ak.unflatten(the_arr, ak.num(hcand.mass,axis=1)) 
+    MTT_cpp_rest = ak.zip(fast_mtt_unflattened) # -> mass, x1, x1_BW, x1_cons, x2, x2_BW, x2_cons
+
+
+    # Extract reconstructed MTT Higgs mass and decay products properties
+    hcand_features = ['pt', 'eta', 'phi'] #no 'px', 'py', 'pz', in lep so far (put can be used in apply_fastMTT.py)
+    leptons_corrected = {}
+
+    for lep_str in ['lep0', 'lep1']:
+        lep = getattr(hcand, lep_str)
+
+        constraint_key = 'x1' if lep_str == 'lep0' else 'x2'
+        constraint = MTT_cpp_rest[constraint_key]
+
+        lep_dict = {}
+
+        for hcand_feature in hcand_features:
+            lep_dict[hcand_feature] = getattr(lep, hcand_feature) / constraint
+
+        # Prepare the reconstructed tau leptons into new hcand columns | part 1/2
+        leptons_corrected[lep_str] = ak.zip(lep_dict)
+
+    # Prepare the reconstructed tau leptons into new hcand columns | part 2/2
+    fastMTT = ak.zip({
+            'lep0': leptons_corrected['lep0'],
+            'lep1': leptons_corrected['lep1'],
+            'mass': fast_mtt_unflattened['mass'],
+        })
+
+    # Attach the new fastMTT entry to the corresponding hcand column
+    hcand['fastMTT'] = fastMTT
+    events = set_ak_column(events, f'hcand_{ch_str}', hcand)
+
+    return events

--- a/httcp/production/fastMTT.py
+++ b/httcp/production/fastMTT.py
@@ -133,13 +133,13 @@ def fastMTT(
     for lep_str in ['lep0', 'lep1']:
         lep = getattr(hcand, lep_str)
 
-        constraint_key = 'x1' if lep_str == 'lep0' else 'x2'
-        constraint = MTT_cpp_rest[constraint_key]
+        modifier_key = 'x1' if lep_str == 'lep0' else 'x2'
+        modifier = MTT_cpp_rest[modifier_key]
 
         lep_dict = {}
 
         for hcand_feature in hcand_features:
-            lep_dict[hcand_feature] = getattr(lep, hcand_feature) / constraint
+            lep_dict[hcand_feature] = getattr(lep, hcand_feature) / modifier
 
         # Prepare the reconstructed tau leptons into new hcand columns | part 1/2
         leptons_corrected[lep_str] = ak.zip(lep_dict)

--- a/httcp/production/main.py
+++ b/httcp/production/main.py
@@ -24,13 +24,14 @@ from httcp.production.generatorZ import genZ
 from httcp.production.met_recoil import gen_boson, met_recoil
 from httcp.production.dilepton_features import hcand_fields
 
-from httcp.production.apply_fastMTT import apply_fastMTT
+#from httcp.production.apply_fastMTT import apply_fastMTT
 from httcp.production.phi_cp import phi_cp
 from httcp.production.aux_columns import jet_pt_def,jets_taggable, number_b_jet, pion_energy_split,gen_lep_fields
 from httcp.production.top_pt_weight import top_pt_weight, gen_parton_top
 from httcp.production.ip_corrector import ip_correction
 from httcp.production.bdt_score import hcp_bdt_score
-from httcp.production.fast_mtt import fast_mtt
+#from httcp.production.fast_mtt import fast_mtt
+from httcp.production.fastMTT import fastMTT
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -59,7 +60,7 @@ set_ak_column_i32 = functools.partial(set_ak_column, value_type=np.int32)
         #fake_factors,
         hcand_fields,
         tauspinner_weight,
-        apply_fastMTT,
+        #apply_fastMTT,
         phi_cp,
         category_ids,
         gen_parton_top,
@@ -72,7 +73,8 @@ set_ak_column_i32 = functools.partial(set_ak_column, value_type=np.int32)
         gen_lep_fields,
         ip_correction,
         hcp_bdt_score,
-        fast_mtt,
+        #fast_mtt,
+        fastMTT,
         },
     produces={
         attach_coffea_behavior,
@@ -91,7 +93,7 @@ set_ak_column_i32 = functools.partial(set_ak_column, value_type=np.int32)
         fake_factors,
         hcand_fields,
         tauspinner_weight,
-        apply_fastMTT,
+        #apply_fastMTT,
         phi_cp,
         category_ids,
         gen_parton_top,
@@ -104,7 +106,8 @@ set_ak_column_i32 = functools.partial(set_ak_column, value_type=np.int32)
         gen_lep_fields,
         ip_correction,
         hcp_bdt_score,
-        fast_mtt,
+        #fast_mtt,
+        fastMTT,
     },
     # whether weight producers should be added and called
     produce_weights=True,
@@ -137,7 +140,8 @@ def main(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
         events = self[gen_boson](events, **kwargs)
         
     events = self[met_recoil](events,**kwargs)
-    events = self[fast_mtt](events,**kwargs)
+    #events = self[fast_mtt](events,**kwargs)
+    events = self[fastMTT](events,**kwargs)
    
     if self.dataset_inst.is_mc:
         
@@ -181,8 +185,8 @@ def main(self: Producer, events: ak.Array, **kwargs) -> ak.Array:
             print("Producing Top pT weights...")
             events = self[top_pt_weight](events, **kwargs)
             
-        print("Producing fastMTT...")
-        events = self[apply_fastMTT](events, **kwargs)
+        #print("Producing fastMTT...")
+        #events = self[apply_fastMTT](events, **kwargs)
     
     
     #Assume that the corrections are done, now we can evaluate bdt scores and produce parameters of interest


### PR DESCRIPTION
Use the C++ wrapping strategy from `fast_mtt.py`, along with its mass output.
Apply the modifier factors x_i to scale visible quantities to their corresponding MTT versions.
The output structure follows the convention from `apply_fastMTT.py` :

```
-> events.hcand_mutau.fastMTT.fields                                                                                                    
<- ['lep0', 'lep1', 'mass'] 
```