### PR TITLE
outsource gef and refactor phicp for gen and reco levels

### DIFF
--- a/httcp/config/variables.py
+++ b/httcp/config/variables.py
@@ -565,18 +565,28 @@ def add_cutflow_features(cfg: od.Config) -> None:
 def phi_cp_variables(cfg: od.Config) -> None:
     n_bins_phi_cp = 8
     cfg.add_variable(
-    name="phi_cp_incl",
-    expression="phi_cp_incl",
-    null_value=EMPTY_FLOAT,
-    binning=(n_bins_phi_cp, 0, 2*np.pi),
-    x_title=rf"$\varphi_{{CP}} (rad)",
+        name="phi_cp_incl",
+        expression="phi_cp_incl",
+        null_value=EMPTY_FLOAT,
+        binning=(n_bins_phi_cp, 0, 2*np.pi),
+        x_title=rf"$\varphi_{{CP}} (rad)",
     )
-    for the_ch in ['mu_pi','mu_rho','mu_a1_3pr_dp_reco','mu_a1_3pr_pv_reco','mu_a1_3pr_pv_mtt','mu_a1_3pr_pv_gef']:
-        spitted_str = the_ch.split('_')
-        if 'a1' in the_ch: 
-            title_str = "\\" + spitted_str[0] + fr" a_1, {spitted_str[2]}" + fr"({spitted_str[3]} {spitted_str[4]})"
-        else:
-             title_str = "\\" + spitted_str[0] + "\\" + spitted_str[1]
+    for the_ch in ['mu_pi','mu_pi_gen','mu_rho','mu_rho_gen',
+                   'mu_a1_1pr','mu_a1_1pr_gen','mu_a1_3pr_dp_reco','mu_a1_3pr_dp_gen',
+                   'mu_a1_3pr_pv_reco','mu_a1_3pr_pv_mtt','mu_a1_3pr_pv_gef','mu_a1_3pr_pv_gen']:
+
+        if the_ch.startswith("mu_a1_3pr"):
+            suffix = the_ch.split("_")[-2:]
+            title_str = fr"\mu a_1, 3pr ({suffix[0]} {suffix[1]})"
+
+        elif the_ch.startswith("mu_a1_1pr"):
+            title_str = r"\mu a_1, 1pr" + (" (gen)" if the_ch.endswith("_gen") else "")
+
+        elif the_ch.startswith(("mu_rho", "mu_pi")):
+            had = the_ch.split("_")[1]
+            title_str = fr"\mu \{had}" + (" (gen)" if the_ch.endswith("_gen") else "")
+
+
         if the_ch == 'mu_rho' or the_ch.startswith('mu_a1_3pr'):
             n_bins_phi_cp = 10
         else: 

--- a/httcp/production/gef.py
+++ b/httcp/production/gef.py
@@ -1,0 +1,123 @@
+# coding: utf-8
+
+"""
+A producer to apply the Global Event Fit (GEF) aka Gottfried–Jackson 
+angle rotation to the hadronic lepton candidates in the hcand columns.
+This steps proceeds after FastMTT. FastMTT corrects the tau momenta 
+amplitude (pT, E), while GEF corrects their direction (eta, phi).
+"""
+
+import functools
+from columnflow.util import maybe_import
+from httcp.util import to_pt_eta_phi_m
+
+np = maybe_import("numpy")
+ak = maybe_import("awkward")
+coffea = maybe_import("coffea")
+maybe_import("coffea.nanoevents.methods.nanoaod")
+
+# helper functions for the unit vectors as the method is buggy
+def unit(v, eps=1e-9):
+    v3 = v.to_3D()
+    mag = v3.mag
+
+    return ak.zip({
+            "x": ak.where(mag > eps, v3.x / mag, 1.0),
+            "y": ak.where(mag > eps, v3.y / mag, 1.0),
+            "z": ak.where(mag > eps, v3.z / mag, 1.0),},
+        with_name="Vector3D", behavior=coffea.nanoevents.methods.vector.behavior)
+
+
+def rotate_to_gj_max(vis, mtt, dsvpv):
+    """
+    Enforce the physical Gottfried–Jackson limit for the tau decay system. 
+    The function computes theta_GJ between the visible system (vis) 
+    and the tau direction approximated by the FastMTT output (mtt).
+    If theta_GJ exceeds theta_max (the kinematic upper bound),
+    the tau momentum is rotated inside the decay plane such that
+    theta_GJ = theta_max.
+    
+    Notes :
+    - All angular and cross-product operations are performed in 3D to maintain numerical stability. 
+      Only the tau energy is carried through from the original four-vector for the final reconstruction.
+    - To preserve small-angle precision, vectors are not fully normalised until the final rotation step.
+    """
+
+    vis3 = vis.to_3D()
+
+    tau_mass = 1.77686
+    tau_comi = ak.zip({
+            "pt": mtt.pt,
+            "eta": dsvpv.eta,
+            "phi": dsvpv.phi,
+            "mass": tau_mass,},
+        with_name="PtEtaPhiMLorentzVector",behavior=coffea.nanoevents.methods.vector.behavior,)
+    tau_comi3 = tau_comi.to_3D()
+
+    # --- Compute theta_GJ preserving small opening angles ---
+    # Normalising vectors would erase tiny deviations, giving theta_gj=0 for nearly parallel vectors.
+    cos_theta_gj = vis3.dot(tau_comi3) / (vis3.mag * tau_comi3.mag)
+    cos_theta_gj = ak.where(cos_theta_gj > 1.0, 1.0,
+                            ak.where(cos_theta_gj < -1.0, -1.0, cos_theta_gj))
+    theta_gj = np.arccos(cos_theta_gj)
+
+    # --- maximal allowed angle : sin(theta_max) = (m_tau^2 - m_vis^2) / (2 m_tau |p_vis|) ---
+    denom = 2.0 * tau_mass * vis3.mag
+    sin_max = ak.where(denom > 0, (tau_mass**2 - vis.mass**2) / denom, 0.0)
+    sin_max = ak.where(sin_max > 1.0, 1.0, ak.where(sin_max < -1.0, -1.0, sin_max))
+    theta_max = np.arcsin(sin_max)
+
+    # --- rotation basis ---
+    eps = 1e-9
+    n1 = unit(vis3)
+    tau_comi_unit = unit(tau_comi3)
+    n3 = unit(n1.cross(tau_comi_unit))
+    n2 = unit(n3.cross(n1))
+
+    # --- decompose mtt momentum in this basis (signed components) ---
+    Porth = tau_comi3.dot(n3)
+    P1 = tau_comi3.dot(n1)
+    P2 = tau_comi3.dot(n2)
+    p_plane_sq = P1**2 + P2**2
+    Ppar = np.sqrt(ak.where(p_plane_sq > 0, p_plane_sq, 0.0))
+
+    # --- compute cos/sin of theta_max ---
+    cosT = np.cos(theta_max)
+    sinT = np.sin(theta_max)
+
+    # --- two candidate in-plane directions at theta_max (both signs) ---
+    n_par_1 = unit(n1 * cosT - n2 * sinT)
+    n_par_2 = unit(n1 * cosT + n2 * sinT)
+
+    # --- reconstruct two candidate full directions keeping Porth unchanged ---
+    new_dir_1 = unit(ak.where(Ppar > 0, n3 * Porth + n_par_1 * Ppar, n1))
+    new_dir_2 = unit(ak.where(Ppar > 0, n3 * Porth + n_par_2 * Ppar, n1))
+
+    # --- choose the candidate closer to the original tau flight direction ---
+    choose_1 = new_dir_1.dot(tau_comi_unit) > new_dir_2.dot(tau_comi_unit)
+    new_dir = ak.where(choose_1, new_dir_1, new_dir_2)
+
+    # --- final spatial momentum (preserve original |p|) & rebuild 4-vector ---
+    new_p = new_dir * tau_comi3.mag
+    E_new = np.sqrt(tau_comi3.mag**2 + tau_mass**2) # equal results to mtt.energy
+
+    tau_rot = ak.zip({
+            "px": new_p.x,
+            "py": new_p.y,
+            "pz": new_p.z,
+            "E": E_new},
+        with_name="PtEtaPhiMLorentzVector", behavior=coffea.nanoevents.methods.vector.behavior,)
+    tau_rot = to_pt_eta_phi_m(tau_rot)
+    
+    # --- check which taus need rotation ---
+    need_rot = theta_gj > theta_max
+
+    tau_final = ak.where(need_rot, tau_rot, tau_comi)
+    tau3_final = tau_final.to_3D()
+
+    cos_theta_rot = vis3.dot(tau3_final) / (vis3.mag * tau3_final.mag)
+    cos_theta_rot = ak.where(cos_theta_rot > 1.0, 1.0,
+                    ak.where(cos_theta_rot < -1.0, -1.0, cos_theta_rot))
+    theta_rot = np.arccos(cos_theta_rot)
+
+    return tau_final, theta_gj, theta_max, theta_rot

--- a/httcp/production/phi_cp.py
+++ b/httcp/production/phi_cp.py
@@ -11,6 +11,7 @@ from columnflow.columnar_util import EMPTY_FLOAT, Route, set_ak_column
 from columnflow.columnar_util import optional_column as optional
 from httcp.util import get_lep_p4, get_ip_p4, to_pt_eta_phi_m
 from httcp.production.PolarimetricA1 import PolarimetricA1
+from httcp.production.gef import unit, rotate_to_gj_max 
 
 np = maybe_import("numpy")
 ak = maybe_import("awkward")
@@ -29,119 +30,13 @@ def pion_mask(tauprod): return np.abs(tauprod.pdgId) == 211
 def get_single_part(array: ak.Array, idx: int) -> ak.Array:
     return ak.firsts(array[:,idx:idx+1])
 
-# helper functions for the unit vectors as the method is buggy
-def unit(v, eps=1e-9):
-    v3 = v.to_3D()
-    mag = v3.mag
-
-    return ak.zip({
-            "x": ak.where(mag > eps, v3.x / mag, 1.0),
-            "y": ak.where(mag > eps, v3.y / mag, 1.0),
-            "z": ak.where(mag > eps, v3.z / mag, 1.0),},
-        with_name="Vector3D", behavior=coffea.nanoevents.methods.vector.behavior)
-
-
-def rotate_to_gj_max(vis, mtt, dsvpv):
-    """
-    Enforce the physical Gottfried–Jackson limit for the tau decay system. 
-    The function computes theta_GJ between the visible system (vis) 
-    and the tau direction approximated by the FastMTT output (mtt).
-    If theta_GJ exceeds theta_max (the kinematic upper bound),
-    the tau momentum is rotated inside the decay plane such that
-    theta_GJ = theta_max.
-    
-    Notes :
-    - All angular and cross-product operations are performed in 3D to maintain numerical stability. 
-      Only the tau energy is carried through from the original four-vector for the final reconstruction.
-    - To preserve small-angle precision, vectors are not fully normalised until the final rotation step.
-    """
-
-    vis3 = vis.to_3D()
-
-    tau_mass = 1.77686
-    tau_comi = ak.zip({
-            "pt": mtt.pt,
-            "eta": dsvpv.eta,
-            "phi": dsvpv.phi,
-            "mass": tau_mass,},
-        with_name="PtEtaPhiMLorentzVector",behavior=coffea.nanoevents.methods.vector.behavior,)
-    tau_comi3 = tau_comi.to_3D()
-
-    # --- Compute theta_GJ preserving small opening angles ---
-    # Normalising vectors would erase tiny deviations, giving theta_gj=0 for nearly parallel vectors.
-    cos_theta_gj = vis3.dot(tau_comi3) / (vis3.mag * tau_comi3.mag)
-    cos_theta_gj = ak.where(cos_theta_gj > 1.0, 1.0,
-                            ak.where(cos_theta_gj < -1.0, -1.0, cos_theta_gj))
-    theta_gj = np.arccos(cos_theta_gj)
-
-    # --- maximal allowed angle : sin(theta_max) = (m_tau^2 - m_vis^2) / (2 m_tau |p_vis|) ---
-    denom = 2.0 * tau_mass * vis3.mag
-    sin_max = ak.where(denom > 0, (tau_mass**2 - vis.mass**2) / denom, 0.0)
-    sin_max = ak.where(sin_max > 1.0, 1.0, ak.where(sin_max < -1.0, -1.0, sin_max))
-    theta_max = np.arcsin(sin_max)
-
-    # --- rotation basis ---
-    eps = 1e-9
-    n1 = unit(vis3)
-    tau_comi_unit = unit(tau_comi3)
-    n3 = unit(n1.cross(tau_comi_unit))
-    n2 = unit(n3.cross(n1))
-
-    # --- decompose mtt momentum in this basis (signed components) ---
-    Porth = tau_comi3.dot(n3)
-    P1 = tau_comi3.dot(n1)
-    P2 = tau_comi3.dot(n2)
-    p_plane_sq = P1**2 + P2**2
-    Ppar = np.sqrt(ak.where(p_plane_sq > 0, p_plane_sq, 0.0))
-
-    # --- compute cos/sin of theta_max ---
-    cosT = np.cos(theta_max)
-    sinT = np.sin(theta_max)
-
-    # --- two candidate in-plane directions at theta_max (both signs) ---
-    n_par_1 = unit(n1 * cosT - n2 * sinT)
-    n_par_2 = unit(n1 * cosT + n2 * sinT)
-
-    # --- reconstruct two candidate full directions keeping Porth unchanged ---
-    new_dir_1 = unit(ak.where(Ppar > 0, n3 * Porth + n_par_1 * Ppar, n1))
-    new_dir_2 = unit(ak.where(Ppar > 0, n3 * Porth + n_par_2 * Ppar, n1))
-
-    # --- choose the candidate closer to the original tau flight direction ---
-    choose_1 = new_dir_1.dot(tau_comi_unit) > new_dir_2.dot(tau_comi_unit)
-    new_dir = ak.where(choose_1, new_dir_1, new_dir_2)
-
-    # --- final spatial momentum (preserve original |p|) & rebuild 4-vector ---
-    new_p = new_dir * tau_comi3.mag
-    E_new = np.sqrt(tau_comi3.mag**2 + tau_mass**2) # equal results to mtt.energy
-
-    tau_rot = ak.zip({
-            "px": new_p.x,
-            "py": new_p.y,
-            "pz": new_p.z,
-            "E": E_new},
-        with_name="PtEtaPhiMLorentzVector", behavior=coffea.nanoevents.methods.vector.behavior,)
-    tau_rot = to_pt_eta_phi_m(tau_rot)
-    
-    # --- check which taus need rotation ---
-    need_rot = theta_gj > theta_max
-
-    tau_final = ak.where(need_rot, tau_rot, tau_comi)
-    tau3_final = tau_final.to_3D()
-
-    cos_theta_rot = vis3.dot(tau3_final) / (vis3.mag * tau3_final.mag)
-    cos_theta_rot = ak.where(cos_theta_rot > 1.0, 1.0,
-                    ak.where(cos_theta_rot < -1.0, -1.0, cos_theta_rot))
-    theta_rot = np.arccos(cos_theta_rot)
-
-    return tau_final, theta_gj, theta_max, theta_rot
-
 
 def prepare_acop_vecs(events: ak.Array, pair_decay_ch):
     tau     = events.hcand_mutau.lep1
     tau_MTT = events.hcand_mutau.fastMTT_BW.lep1
     tauprod = events.tau_decay_prods_mutau_lep1
     muon    = events.hcand_mutau.lep0   
-    PVBS      = events.PVBS
+    PVBS    = events.PVBS
 
     p1 = p2 = get_lep_p4(muon)
     r1 = r2 = get_ip_p4(muon)

--- a/httcp/production/phi_cp.py
+++ b/httcp/production/phi_cp.py
@@ -8,7 +8,7 @@ import functools
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import
 from columnflow.columnar_util import EMPTY_FLOAT, set_ak_column
-from httcp.util import get_lep_p4, get_ip_p4, get_gen_ip_p4
+from httcp.util import get_lep_p4, get_ip_p4
 from httcp.production.PolarimetricA1 import PolarimetricA1
 from httcp.production.gef import unit, rotate_to_gj_max 
 
@@ -41,8 +41,8 @@ def prepare_acop_vecs(events: ak.Array, pair_decay_ch):
     PVBS        = events.PVBS
 
     if pair_decay_ch.endswith("_gen"):
-        r1  = r2 = get_gen_ip_p4(muon)
-        ip2 = get_gen_ip_p4(tau)
+        r1  = r2 = get_ip_p4(muon)
+        ip2 = get_ip_p4(tau)
         ch1 = events.gen_lep.lep0.charge
         tau, tauprod, muon = tau_gen, tauprod_gen, muon_gen
     else:
@@ -66,12 +66,8 @@ def prepare_acop_vecs(events: ak.Array, pair_decay_ch):
         sorted_idx = ak.argsort(ss_pions.pt, ascending=False)
         best_pion = ak.drop_none(ak.firsts(ss_pions[sorted_idx],axis=1)[..., np.newaxis])
         p2 = get_lep_p4(best_pion) # for the tau -> rho decay, p1 - is 4-vector of the charged pion and r1 is 4-vector of the neutral pion
-        
         # Create 4-vectors of tau impact parameters
-        if pair_decay_ch.endswith("_gen"):
-            r2 = get_gen_ip_p4(tau)
-        else:
-            r2 = get_ip_p4(tau)
+        r2 = get_ip_p4(tau)
         r2 = ak.drop_none(ak.mask(r2, r2.rho2 > 0))
 
     elif pair_decay_ch.startswith("mu_rho"):

--- a/httcp/production/phi_cp.py
+++ b/httcp/production/phi_cp.py
@@ -39,16 +39,15 @@ def prepare_acop_vecs(events: ak.Array, pair_decay_ch):
     muon        = events.hcand_mutau.lep0
     muon_gen    = events.gen_lep.lep0
     PVBS        = events.PVBS
+    ch1         = muon.charge # take the same charge for reco and gen
 
     if pair_decay_ch.endswith("_gen"):
         r1  = r2 = get_ip_p4(muon)
         ip2 = get_ip_p4(tau)
-        ch1 = events.gen_lep.lep0.charge
         tau, tauprod, muon = tau_gen, tauprod_gen, muon_gen
     else:
         r1  = r2 = get_ip_p4(muon)
         ip2 = get_ip_p4(tau)
-        ch1 = muon.charge
 
     p1 = p2 = get_lep_p4(muon)
 

--- a/httcp/production/phi_cp.py
+++ b/httcp/production/phi_cp.py
@@ -7,9 +7,8 @@ import functools
 
 from columnflow.production import Producer, producer
 from columnflow.util import maybe_import
-from columnflow.columnar_util import EMPTY_FLOAT, Route, set_ak_column
-from columnflow.columnar_util import optional_column as optional
-from httcp.util import get_lep_p4, get_ip_p4, to_pt_eta_phi_m
+from columnflow.columnar_util import EMPTY_FLOAT, set_ak_column
+from httcp.util import get_lep_p4, get_ip_p4, get_gen_ip_p4
 from httcp.production.PolarimetricA1 import PolarimetricA1
 from httcp.production.gef import unit, rotate_to_gj_max 
 
@@ -32,16 +31,26 @@ def get_single_part(array: ak.Array, idx: int) -> ak.Array:
 
 
 def prepare_acop_vecs(events: ak.Array, pair_decay_ch):
-    tau     = events.hcand_mutau.lep1
-    tau_MTT = events.hcand_mutau.fastMTT_BW.lep1
-    tauprod = events.tau_decay_prods_mutau_lep1
-    muon    = events.hcand_mutau.lep0   
-    PVBS    = events.PVBS
+    tau         = events.hcand_mutau.lep1
+    tau_MTT     = events.hcand_mutau.fastMTT_BW.lep1
+    tau_gen     = events.gen_lep.lep1
+    tauprod     = events.tau_decay_prods_mutau_lep1
+    tauprod_gen = events.gentau_decay_prods_mutau_lep1 #here adapt this
+    muon        = events.hcand_mutau.lep0
+    muon_gen    = events.gen_lep.lep0
+    PVBS        = events.PVBS
+
+    if pair_decay_ch.endswith("_gen"):
+        r1  = r2 = get_gen_ip_p4(muon)
+        ip2 = get_gen_ip_p4(tau)
+        ch1 = events.gen_lep.lep0.charge
+        tau, tauprod, muon = tau_gen, tauprod_gen, muon_gen
+    else:
+        r1  = r2 = get_ip_p4(muon)
+        ip2 = get_ip_p4(tau)
+        ch1 = muon.charge
 
     p1 = p2 = get_lep_p4(muon)
-    r1 = r2 = get_ip_p4(muon)
-    ch1 = muon.charge
-    ip2 = get_ip_p4(tau)
 
     # initialise variables for GJ rotation case
     theta_gj, theta_max, theta_rot, empty = (
@@ -50,17 +59,22 @@ def prepare_acop_vecs(events: ak.Array, pair_decay_ch):
     dsvpv = ak.zip({"x": empty, "y": empty, "z": empty},
         with_name="Vector3D", behavior=coffea.nanoevents.methods.vector.behavior)
     
-    if pair_decay_ch == "mu_pi":
+    if pair_decay_ch.startswith("mu_pi"):
         charged_pions = ak.drop_none(ak.mask(tauprod,pion_mask(tauprod)))
         pi_ch, tau_ch = ak.broadcast_arrays(charged_pions.charge , ak.firsts(tau.charge))
         ss_pions = ak.drop_none(ak.mask(charged_pions, pi_ch == tau_ch))
         sorted_idx = ak.argsort(ss_pions.pt, ascending=False)
         best_pion = ak.drop_none(ak.firsts(ss_pions[sorted_idx],axis=1)[..., np.newaxis])
         p2 = get_lep_p4(best_pion) # for the tau -> rho decay, p1 - is 4-vector of the charged pion and r1 is 4-vector of the neutral pion
-        r2 = get_ip_p4(tau) # Create 4-vectors of tau impact parameters
+        
+        # Create 4-vectors of tau impact parameters
+        if pair_decay_ch.endswith("_gen"):
+            r2 = get_gen_ip_p4(tau)
+        else:
+            r2 = get_ip_p4(tau)
         r2 = ak.drop_none(ak.mask(r2, r2.rho2 > 0))
 
-    elif pair_decay_ch == "mu_rho":
+    elif pair_decay_ch.startswith("mu_rho"):
         charged_pions = ak.drop_none(ak.mask(tauprod,pion_mask(tauprod)))
         pi_ch, tau_ch = ak.broadcast_arrays(charged_pions.charge , ak.firsts(tau.charge))
         ss_pions = ak.drop_none(ak.mask(charged_pions, pi_ch == tau_ch))
@@ -73,7 +87,7 @@ def prepare_acop_vecs(events: ak.Array, pair_decay_ch):
         r2 = get_lep_p4(em_particles).sum(1)[...,np.newaxis]
         r2 = ak.drop_none(ak.mask(r2, r2.rho2 > 0)) #This is needed to remove empty events because .sum() returns 4-vector filled with zeros
     
-    elif pair_decay_ch == "mu_a1_1pr": 
+    elif pair_decay_ch.startswith("mu_a1_1pr"):
         charged_pions = ak.drop_none(ak.mask(tauprod,pion_mask(tauprod)))
         pi_ch, tau_ch = ak.broadcast_arrays(charged_pions.charge , ak.firsts(tau.charge))
         ss_pions = ak.drop_none(ak.mask(charged_pions, pi_ch == tau_ch))
@@ -86,7 +100,7 @@ def prepare_acop_vecs(events: ak.Array, pair_decay_ch):
         r2 = get_lep_p4(em_particles).sum(1)[...,np.newaxis]
         r2 = ak.drop_none(ak.mask(r2, r2.rho2 > 0)) #This is needed to remove empty events because .sum() returns 4-vector filled with zeros
        
-    elif pair_decay_ch == "mu_a1_3pr_dp_reco":
+    elif pair_decay_ch.startswith("mu_a1_3pr_dp"):
         charged_pion = ak.drop_none(ak.mask(tauprod, pion_mask(tauprod)))
         #Create sum of charges of the pions = -1*charge of tau = same charge pion 
         ss_ch, _ = ak.broadcast_arrays(ak.sum(charged_pion.charge, axis=1),
@@ -116,7 +130,7 @@ def prepare_acop_vecs(events: ak.Array, pair_decay_ch):
         p2 = os_pi #charge of this pion is the same as the charge of tau
         r2 = sel_ss_pi #charge of this pion is opposite to the charge of tau
 
-    elif pair_decay_ch.startswith('mu_a1_3pr_pv') and 'gen' not in pair_decay_ch:
+    elif pair_decay_ch.startswith('mu_a1_3pr_pv'):
 
         # Select tau four-momentum based on the reconstruction method
         if pair_decay_ch == "mu_a1_3pr_pv_reco":
@@ -125,6 +139,8 @@ def prepare_acop_vecs(events: ak.Array, pair_decay_ch):
             tau_p4 = get_lep_p4(tau_MTT)
         elif pair_decay_ch == "mu_a1_3pr_pv_gef":
             tau_p4 = get_lep_p4(tau_MTT)
+        elif pair_decay_ch == "mu_a1_3pr_pv_gen":
+            tau_p4 = get_lep_p4(tau)
 
         # Select charged pions from the tau decay
         charged_pion = ak.drop_none(ak.mask(tauprod, pion_mask(tauprod)))
@@ -225,7 +241,7 @@ def prepare_acop_vecs(events: ak.Array, pair_decay_ch):
     ip2 = ak.drop_none(ak.mask(ip2, final_mask))
     ch1 = ak.drop_none(ak.mask(ch1, final_mask))
 
-    if pair_decay_ch == "mu_pi":
+    if pair_decay_ch.startswith("mu_pi"):
         do_phase_shift = ak.zeros_like(r1.energy, dtype=np.bool_) 
 
     else:
@@ -298,16 +314,18 @@ def produce_alpha(vecs_p4) -> ak.Array:
     return alpha
     
 
-channels = ['mu_pi','mu_rho','mu_a1_1pr',
-            'mu_a1_3pr_dp_reco',
-            'mu_a1_3pr_pv_reco','mu_a1_3pr_pv_mtt','mu_a1_3pr_pv_gef']
+channels = ['mu_pi','mu_pi_gen',
+            'mu_rho','mu_rho_gen',
+            'mu_a1_1pr','mu_a1_1pr_gen',
+            'mu_a1_3pr_dp_reco','mu_a1_3pr_dp_gen',
+            'mu_a1_3pr_pv_reco','mu_a1_3pr_pv_mtt','mu_a1_3pr_pv_gef','mu_a1_3pr_pv_gen']
 
 @producer(
     uses={
         "hcand_*","tau_decay_prods_*","PVBS.*"},
     produces={
         f"phi_cp_{the_ch}" for the_ch in channels
-    }| {
+    } | {
         'theta_gj_mu_a1_3pr_pv_gef',
         'theta_max_mu_a1_3pr_pv_gef',
         'theta_rot_mu_a1_3pr_pv_gef',
@@ -331,6 +349,7 @@ def phi_cp(
         phi_cp = ak.where(np.isfinite(phi_cp), phi_cp, EMPTY_FLOAT)
         events = set_ak_column_f32(events, f"phi_cp_{the_ch}",phi_cp)
 
+        
         if the_ch == "mu_a1_3pr_pv_gef":
 
             empty_event_mask = None
@@ -366,6 +385,7 @@ def phi_cp(
             events = set_ak_column_f32(events, f"dsvpv_y",dsvpv_y)
             events = set_ak_column_f32(events, f"dsvpv_z",dsvpv_z)
             events = set_ak_column_f32(events, f"dsvpv_mag",dsvpv_mag)
+
 
         #alpha = np.ones_like(events.event)*EMPTY_FLOAT
         # alpha_per_ch = produce_alpha(vecs_p4)

--- a/httcp/util.py
+++ b/httcp/util.py
@@ -52,10 +52,6 @@ def get_ip_p4(part): return ak.zip({f'{var}': part[f'IP{var}']for var in ['x', '
                                    with_name="LorentzVector",
                                    behavior=coffea.nanoevents.methods.vector.behavior)# # lambda function to get 4-vector from the particle objects
 
-def get_gen_ip_p4(part): return ak.zip({f'{var}': part[f'gen_ip_{var}']for var in ['x', 'y', 'z']} | {'t': ak.zeros_like(part.IPx)},
-                                   with_name="LorentzVector",
-                                   behavior=coffea.nanoevents.methods.vector.behavior)
-
 def get_vec_p3(part,vec_column=None): 
     if vec_column is not None:
         return ak.zip({f'{var}': part[f'{vec_column}{var}']for var in ['x', 'y', 'z']},

--- a/httcp/util.py
+++ b/httcp/util.py
@@ -52,6 +52,10 @@ def get_ip_p4(part): return ak.zip({f'{var}': part[f'IP{var}']for var in ['x', '
                                    with_name="LorentzVector",
                                    behavior=coffea.nanoevents.methods.vector.behavior)# # lambda function to get 4-vector from the particle objects
 
+def get_gen_ip_p4(part): return ak.zip({f'{var}': part[f'gen_ip_{var}']for var in ['x', 'y', 'z']} | {'t': ak.zeros_like(part.IPx)},
+                                   with_name="LorentzVector",
+                                   behavior=coffea.nanoevents.methods.vector.behavior)
+
 def get_vec_p3(part,vec_column=None): 
     if vec_column is not None:
         return ak.zip({f'{var}': part[f'{vec_column}{var}']for var in ['x', 'y', 'z']},


### PR DESCRIPTION
Commit 1 ) Outsourcing of the GEF script in /production
Commit 2 ) Refactorisation of the phicp pipeline to account for reco and gen levels in all mutau decay channels
- -> propagation into `variables.py`
- -> new util function : `get_gen_ip_p4()`

**CAVE :** names for `tauprod_gen = events.gentau_decay_prods_mutau_lep1` and `gen_ip_x` must match the produced output

_Edits :_
Commit 3 ) Stepan and I just concluded that it's best to unify the notations for the IP columns on reco and gen levels, so we only need on util functions :  `get_ip_p4()`
Commit 4 ) Take the same charge for gen and reco muon, as the charge field (will) only exist in the reco level muon object